### PR TITLE
remove mypy from linting, clean up files.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,12 +30,12 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.902
-    hooks:
-      - id: mypy
-        exclude: '^(docs|tasks|tests)|setup|job_manager\.py'
-        args: [--ignore-missing-imports]
+#  - repo: https://github.com/pre-commit/mirrors-mypy
+#    rev: v0.902
+#    hooks:
+#      - id: mypy
+#        exclude: '^(docs|tasks|tests)|setup|job_manager\.py'
+#        args: [--ignore-missing-imports]
 
   - repo: https://github.com/psf/black
     rev: 22.3.0

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ docker && docker compose || docker-compose
 
 (above just runs docker and docker-compose and checks if both work)
 
-### Build and Run 
+### Build and Run
 
-8Knot is a multi-container application. 
+8Knot is a multi-container application.
 
 The webserver, worker-pool, and cache containers communicate with one another via docker network.
 

--- a/app.py
+++ b/app.py
@@ -24,9 +24,7 @@ import os
 import logging
 from app_global import celery_manager, celery_app
 
-logging.basicConfig(
-    format="%(asctime)s %(levelname)-8s %(message)s", level=logging.DEBUG
-)
+logging.basicConfig(format="%(asctime)s %(levelname)-8s %(message)s", level=logging.DEBUG)
 
 # GLOBAL VARIABLE DECLARATIONS
 engine = None
@@ -74,9 +72,7 @@ def _project_list_query():
     df_search_bar = augur_db.run_query(pr_query)
 
     # handling case sensitive options for search bar
-    entries = np.concatenate(
-        (df_search_bar.rg_name.unique(), df_search_bar.repo_git.unique()), axis=None
-    )
+    entries = np.concatenate((df_search_bar.rg_name.unique(), df_search_bar.repo_git.unique()), axis=None)
     entries = entries.tolist()
     entries.sort(key=lambda item: (item, len(item)))
 
@@ -85,11 +81,7 @@ def _project_list_query():
     all_entries = list(zip(lower_entries, entries))
 
     # generating dictionary with the git urls as the key and the repo_id and name as a list as the value pair
-    repo_dict = (
-        df_search_bar[["repo_git", "repo_id", "repo_name"]]
-        .set_index("repo_git")
-        .T.to_dict("list")
-    )
+    repo_dict = df_search_bar[["repo_git", "repo_id", "repo_name"]].set_index("repo_git").T.to_dict("list")
 
     # generating dictionary with the org name as the key and the git repos of the org in a list as the value pair
     org_dict = df_search_bar.groupby("rg_name")["repo_git"].apply(list).to_dict()
@@ -212,11 +204,7 @@ app.layout = dbc.Container(
                             },
                         ),
                         dcc.Loading(
-                            children=[
-                                html.Div(
-                                    id="results-output-container", className="mb-4"
-                                )
-                            ],
+                            children=[html.Div(id="results-output-container", className="mb-4")],
                             color="#119DFF",
                             type="dot",
                             fullscreen=True,

--- a/app_global.py
+++ b/app_global.py
@@ -8,8 +8,6 @@ celery_app = Celery(
     backend=worker_settings.REDIS_URL,
 )
 
-celery_app.conf.update(
-    task_time_limit=84600, task_acks_late=True, task_track_started=True
-)
+celery_app.conf.update(task_time_limit=84600, task_acks_late=True, task_track_started=True)
 
 celery_manager = CeleryManager(celery_app=celery_app)

--- a/cache_manager/cache_manager.py
+++ b/cache_manager/cache_manager.py
@@ -223,9 +223,7 @@ class CacheManager:
         out_df = pd.DataFrame()
         for r in results:
             try:
-                out_df = pd.concat(
-                    [out_df, pd.read_csv(io.StringIO(r), sep=",")], ignore_index=True
-                )
+                out_df = pd.concat([out_df, pd.read_csv(io.StringIO(r), sep=",")], ignore_index=True)
             except:
                 # some json lists are empty and aren't deserializable
                 e = sys.exc_info()[0]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     ports:
       - 8050:8050
     depends_on:
-      - callback-worker 
-      - query-worker 
+      - callback-worker
+      - query-worker
       - cache
     env_file:
       - ./env.list

--- a/docker/Dockerfile.flower
+++ b/docker/Dockerfile.flower
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-39 
+FROM registry.access.redhat.com/ubi9/python-39
 
 # need this for the Dash app
 EXPOSE 8050

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-39 
+FROM registry.access.redhat.com/ubi9/python-39
 
 # need this for the Dash app
 EXPOSE 8050

--- a/docker/Dockerfile.supervisor_workers
+++ b/docker/Dockerfile.supervisor_workers
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-39 
+FROM registry.access.redhat.com/ubi9/python-39
 
 # need this for the Dash app
 EXPOSE 8050

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-39 
+FROM registry.access.redhat.com/ubi9/python-39
 
 # need this for the Dash app
 EXPOSE 8050


### PR DESCRIPTION
mypy was returning error: "8Knot is not a valid Python package name." This is true, but we want to ignore this error.
However, we can't ignore it because mypy won't report the error message that the error corresponds to, so we can't explicitly ignore that error.

Therefore, we're removing mypy from pre-commit linting for the forseeable future. Other linting w/ black and pre-commit will still happen.

Signed-off-by: James Kunstle <jkunstle@bu.edu>