### PR TITLE
solved query deadlock- webserver starts query jobs

### DIFF
--- a/app_layout.py
+++ b/app_layout.py
@@ -23,6 +23,7 @@ layout = dbc.Container(
     [
         # componets to store data from queries
         dcc.Store(id="repo-choices", storage_type="session", data=[]),
+        dcc.Store(id="job-ids", storage_type="session", data=[]),
         dcc.Location(id="url"),
         dbc.Row(
             [
@@ -32,7 +33,12 @@ layout = dbc.Container(
                     [
                         html.H1("8Knot Community Data", className="text-center"),
                         # search bar with buttons
-                        dbc.Label("Select Github repos or orgs:", html_for="projects", width="auto", size="lg"),
+                        dbc.Label(
+                            "Select Github repos or orgs:",
+                            html_for="projects",
+                            width="auto",
+                            size="lg",
+                        ),
                         html.Div(
                             [
                                 html.Div(

--- a/pages/visualizations/viz_template.py
+++ b/pages/visualizations/viz_template.py
@@ -37,7 +37,7 @@ PAGE = "overview"  # EDIT FOR PAGE USED
 VIZ_ID = "shortname-of-viz"  # UNIQUE IDENTIFIER FOR CALLBAKCS, MUST BE UNIQUE
 
 """
-ADDITIONAL INPUT/OUTPUT PARAMETER NAMES FOR DASH CALLBACKS 
+ADDITIONAL INPUT/OUTPUT PARAMETER NAMES FOR DASH CALLBACKS
 If you add a new Input() or Output() to your visualization, name them here
 
 paramter_1 = "name-of-additional-graph-input"
@@ -215,8 +215,8 @@ def NAME_OF_VISUALIZATION_graph(repolist, interval):
 
 
 def process_data(df: pd.DataFrame, interval):
-    """Implement your custom data-processing logic in this function. 
-    The output of this function is the data you intend to create a visualization with, 
+    """Implement your custom data-processing logic in this function.
+    The output of this function is the data you intend to create a visualization with,
     requiring no further processing."""
 
     # convert to datetime objects rather than strings


### PR DESCRIPTION
Regular non-scheduled callback starts the AsyncResult jobs. Then a background callback waits for them and reports completion to the loading animation.

verified that this worked on podman-compose as well, and on low-resources.

also added result forgetting to prevent meaningless task results from stacking up in backend.

Signed-off-by: James Kunstle <jkunstle@bu.edu>