### PR TITLE
alternate ports experiment for multiple instances on a compute

### DIFF
--- a/cache_manager/cache_manager.py
+++ b/cache_manager/cache_manager.py
@@ -47,7 +47,7 @@ class CacheManager:
         self._redis = StrictRedis(
             # openshift will reconcile the 'redis' naming via the dns
             host=os.getenv("REDIS_SERVICE_HOST", "localhost"),
-            port=os.getenv("REDIS_SERVICE_PORT", "6379"),
+            port=os.getenv("REDIS_SERVICE_PORT", "6388"),
             password=os.getenv("REDIS_PASSWORD", ""),
             decode_responses=decode_value,
         )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./env.list
     environment:
       REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6388
+      REDIS_SERVICE_PORT: 6380
     restart: always
 
   callback-worker:
@@ -26,7 +26,7 @@ services:
       - ./env.list
     environment:
       REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6388
+      REDIS_SERVICE_PORT: 6380
     restart: always
 
   query-worker:
@@ -40,13 +40,14 @@ services:
       - ./env.list
     environment:
       REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6388
+      REDIS_SERVICE_PORT: 6380
     restart: always
 
   cache:
     image: redis
+    command: --port 6380
     ports:
-      - 6388:6388
+      - 6380:6380
     restart: always
 
   flower:
@@ -62,6 +63,6 @@ services:
       - ./env.list
     environment:
       REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6388
+      REDIS_SERVICE_PORT: 6380
     ports:
       - 5557:5557

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile.server
     ports:
-      - 8050:8050
+      - 8055:8050
     depends_on:
       - callback-worker
       - query-worker
@@ -13,7 +13,7 @@ services:
       - ./env.list
     environment:
       REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6379
+      REDIS_SERVICE_PORT: 6388
     restart: always
 
   callback-worker:
@@ -26,7 +26,7 @@ services:
       - ./env.list
     environment:
       REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6379
+      REDIS_SERVICE_PORT: 6388
     restart: always
 
   query-worker:
@@ -40,13 +40,13 @@ services:
       - ./env.list
     environment:
       REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6379
+      REDIS_SERVICE_PORT: 6388
     restart: always
 
   cache:
     image: redis
     ports:
-      - 6379:6379
+      - 6380:6380
     restart: always
 
   flower:
@@ -62,6 +62,6 @@ services:
       - ./env.list
     environment:
       REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6379
+      REDIS_SERVICE_PORT: 6388
     ports:
-      - 5555:5555
+      - 5557:5557

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
   cache:
     image: redis
     ports:
-      - 6380:6380
+      - 6388:6388
     restart: always
 
   flower:

--- a/docker/Dockerfile.flower
+++ b/docker/Dockerfile.flower
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/python-39
 
 # need this for the Dash app
-EXPOSE 8050
+EXPOSE 8055
 
 # install pipenv
 RUN pip --no-cache-dir install pipenv

--- a/docker/Dockerfile.flower
+++ b/docker/Dockerfile.flower
@@ -29,5 +29,5 @@ COPY ./ /explorer/
 
 # run worker
 # CMD [ "rq", "worker", "-c", "worker_settings" ]
-# CMD ["celery", "-A", "app:celery_app", "--broker", "redis://:@cache:6379", "flower"]
+# CMD ["celery", "-A", "app:celery_app", "--broker", "redis://:@cache:6380", "flower"]
 CMD ["celery", "-A", "app:celery_app", "flower"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/python-39
 
 # need this for the Dash app
-EXPOSE 8050
+EXPOSE 8055
 
 # install pipenv
 # RUN pip --no-cache-dir install pipenv
@@ -30,4 +30,4 @@ COPY ./ /explorer/
 # Description of how to choose the number of workers and threads.
 # common wisdom is (2*CPU)+1 workers:
 # https://medium.com/building-the-system/gunicorn-3-means-of-concurrency-efbb547674b7
-CMD [ "gunicorn", "--bind", ":8050", "app:server", "--workers", "4", "--threads", "2" ]
+CMD [ "gunicorn", "--bind", ":8055", "app:server", "--workers", "4", "--threads", "2" ]

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/python-39
 
 # need this for the Dash app
-EXPOSE 8050
+EXPOSE 8055
 
 # install pipenv
 RUN pip --no-cache-dir install pipenv

--- a/scripts/launch_dev.sh
+++ b/scripts/launch_dev.sh
@@ -24,12 +24,12 @@ which podman || CONTAINER_CMD=docker
 if [ -z "$1" ]
     then
         echo "No Redis remap-port supplied."
-        echo "Defaulting to port: 6379"
+        echo "Defaulting to port: 6388"
         printf "\n"
-        REDIS_PORT_MAP=6379;
+        REDIS_PORT_MAP=6388;
     else
         echo "Redis remap-port supplied.";
-        echo "Mapping container port 6379 to: $1";
+        echo "Mapping container port 6388 to: $1";
         printf "\n";
         REDIS_PORT_MAP=$1;
 fi
@@ -38,7 +38,7 @@ fi
 ${CONTAINER_CMD} network create eightknot-network;
 
 # create a redis instance inside of a container, on our Docker network, mapped to its respective port.
-${CONTAINER_CMD} run --rm -itd --name redis --net eightknot-network -p $REDIS_PORT_MAP:6379 redis;
+${CONTAINER_CMD} run --rm -itd --name redis --net eightknot-network -p $REDIS_PORT_MAP:6388 redis;
 
 # grab the route to the redis server from the running redis container
 REDIS_CONTAINER_URL=$(${CONTAINER_CMD} inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' redis);

--- a/scripts/launch_dev.sh
+++ b/scripts/launch_dev.sh
@@ -24,12 +24,12 @@ which podman || CONTAINER_CMD=docker
 if [ -z "$1" ]
     then
         echo "No Redis remap-port supplied."
-        echo "Defaulting to port: 6388"
+        echo "Defaulting to port: 6380"
         printf "\n"
-        REDIS_PORT_MAP=6388;
+        REDIS_PORT_MAP=6380;
     else
         echo "Redis remap-port supplied.";
-        echo "Mapping container port 6388 to: $1";
+        echo "Mapping container port 6380 to: $1";
         printf "\n";
         REDIS_PORT_MAP=$1;
 fi
@@ -38,7 +38,7 @@ fi
 ${CONTAINER_CMD} network create eightknot-network;
 
 # create a redis instance inside of a container, on our Docker network, mapped to its respective port.
-${CONTAINER_CMD} run --rm -itd --name redis --net eightknot-network -p $REDIS_PORT_MAP:6388 redis;
+${CONTAINER_CMD} run --rm -itd --name redis --net eightknot-network -p $REDIS_PORT_MAP:6380 redis;
 
 # grab the route to the redis server from the running redis container
 REDIS_CONTAINER_URL=$(${CONTAINER_CMD} inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' redis);

--- a/worker_settings.py
+++ b/worker_settings.py
@@ -1,7 +1,7 @@
 import os
 
 redis_host = "{}".format(os.getenv("REDIS_SERVICE_HOST", "localhost"))
-redis_port = "{}".format(os.getenv("REDIS_SERVICE_PORT", "6379"))
+redis_port = "{}".format(os.getenv("REDIS_SERVICE_PORT", "6388"))
 redis_password = "{}@".format(os.getenv("REDIS_PASSWORD", ""))
 
 REDIS_URL = f"redis://:{redis_password}{redis_host}:{redis_port}"


### PR DESCRIPTION
Opening PR solely to help facilitate the parameterization of ports by exposing what I thought would work to eliminate this error when changing redis ports and eightknot ports: 
```
flower_1           |     raise ConnectionError(str(exc)) from exc
flower_1           | kombu.exceptions.OperationalError: Error 111 connecting to cache:6388. Connection refused.
callback-worker_1  | [2023-04-29 18:51:54,827: ERROR/MainProcess] consumer: Cannot connect to redis://cache:6388//: Error 111 connecting to cache:6388. Connection refused..
callback-worker_1  | Trying again in 6.00 seconds... (3/100)
```