### PR TITLE
push admin groups query to client startup

### DIFF
--- a/db_manager/augur_manager.py
+++ b/db_manager/augur_manager.py
@@ -116,15 +116,11 @@ class AugurManager:
             for v in env_values:
 
                 if v not in os.environ:
-                    logging.critical(
-                        f'Required environment variable "{v}" not available.'
-                    )
+                    logging.critical(f'Required environment variable "{v}" not available.')
                     return None
 
                 if os.getenv(v) is None:
-                    logging.critical(
-                        f'Required environment variable: "{v}" available but none.'
-                    )
+                    logging.critical(f'Required environment variable: "{v}" available but none.')
                     return None
 
             # have confirmed that necessary environment variables exist- proceed.
@@ -168,9 +164,7 @@ class AugurManager:
             pd.DataFrame: Results from SQL query.
         """
         if self.engine is None:
-            logging.critical(
-                "No engine- please use 'get_engine' method to create engine."
-            )
+            logging.critical("No engine- please use 'get_engine' method to create engine.")
             return None
 
         result_df = pd.DataFrame()
@@ -262,38 +256,27 @@ class AugurManager:
 
         # create a list of dictionaries for the MultiSelect dropdown
         # Output is of the form: [{"label": org_name, "value": lower(org_name)}, ...]
-        multiselect_orgs = [
-            {"label": v, "value": str.lower(v)}
-            for v in list(df_search_bar["rg_name"].unique())
-        ]
+        multiselect_orgs = [{"label": v, "value": str.lower(v)} for v in list(df_search_bar["rg_name"].unique())]
 
         # combine options for multiselect component and sort them by the length
         # of their label (shorter comes first because it sorts ascending by default.)
         self.multiselect_options = multiselect_repos + multiselect_orgs
-        self.multiselect_options = sorted(
-            self.multiselect_options, key=lambda i: i["label"]
-        )
+        self.multiselect_options = sorted(self.multiselect_options, key=lambda i: i["label"])
 
         # create a dictionary to map github orgs to their constituent repos.
         # used when the user selects an org
         # Output is of the form: {group_name: [rid1, rid2, ...], group_name: [...], ...}
         df_lower_repo_names = df_search_bar.copy()
         df_lower_repo_names["rg_name"] = df_lower_repo_names["rg_name"].apply(str.lower)
-        self.org_name_to_repos_dict = (
-            df_lower_repo_names.groupby("rg_name")["repo_id"].apply(list).to_dict()
-        )
+        self.org_name_to_repos_dict = df_lower_repo_names.groupby("rg_name")["repo_id"].apply(list).to_dict()
         self.org_names = list(self.org_name_to_repos_dict.keys())
 
         # create a dictionary that maps the github url to the repo_id in database
         df_repo_git_id = df_search_bar.copy()
         df_repo_git_id = df_repo_git_id[["repo_git", "repo_id"]]
-        self.repo_git_to_repo_id = pd.Series(
-            df_repo_git_id.repo_id.values, index=df_repo_git_id["repo_git"]
-        ).to_dict()
+        self.repo_git_to_repo_id = pd.Series(df_repo_git_id.repo_id.values, index=df_repo_git_id["repo_git"]).to_dict()
         # self.repo_id_to_repo_git = {value: key for (key, value) in self.repo_git_to_repo_id.items()}
-        self.repo_id_to_repo_git = pd.Series(
-            df_repo_git_id.repo_git.values, index=df_repo_git_id["repo_id"]
-        ).to_dict()
+        self.repo_id_to_repo_git = pd.Series(df_repo_git_id.repo_git.values, index=df_repo_git_id["repo_id"]).to_dict()
 
         # making first selection for the search bar
         self.initial_search_option = self.multiselect_options[0]
@@ -383,14 +366,10 @@ class AugurManager:
                     data["refresh_token"],
                 )
             else:
-                logging.critical(
-                    f"AUGUR-MANAGER FAILURE: Couldn't get Bearer Token, response not Validated."
-                )
+                logging.critical(f"AUGUR-MANAGER FAILURE: Couldn't get Bearer Token, response not Validated.")
                 return None, None, None, None
         else:
-            logging.critical(
-                f"AUGUR-MANAGER FAILURE: Couldn't get Bearer Token, non-200 status."
-            )
+            logging.critical(f"AUGUR-MANAGER FAILURE: Couldn't get Bearer Token, non-200 status.")
             return None, None, None, None
 
     def make_authenticated_request(self, headers={}, params={}):
@@ -401,9 +380,7 @@ class AugurManager:
         """
         headers["Authorization"] = f"Client {self.client_secret}"
 
-        return requests.post(
-            self.session_generate_endpoint, headers=headers, params=params
-        )
+        return requests.post(self.session_generate_endpoint, headers=headers, params=params)
 
     def make_user_request(self, access_token, headers={}, params={}):
         """Large parts of code written by John McGinness, University of Missouri
@@ -413,55 +390,49 @@ class AugurManager:
         """
         headers["Authorization"] = f"Client {self.client_secret}, Bearer {access_token}"
 
-        result = requests.post(
-            self.user_groups_endpoint, headers=headers, params=params
-        )
+        result = requests.post(self.user_groups_endpoint, headers=headers, params=params)
 
         if result.status_code == 200:
             return result.json()
 
-    def make_admin_name_request(self, access_token, headers={}, params={}):
+    def make_admin_name_request(self, headers={}, params={}):
         """Large parts of code written by John McGinness, University of Missouri
         Added by James Kunstle.
 
         Returns:
             _type_: _description_
         """
-        headers["Authorization"] = f"Client {self.client_secret}, Bearer {access_token}"
+        headers["Authorization"] = f"Client {self.client_secret}"
 
-        result = requests.post(self.admin_name_endpoint, headers=headers, params=params)
+        result = requests.get(self.admin_name_endpoint, headers=headers, params=params)
 
         if result.status_code == 200:
             return result.json()
 
-    def make_admin_group_names_request(self, access_token, headers={}, params={}):
+    def make_admin_group_names_request(self, headers={}, params={}):
         """Large parts of code written by John McGinness, University of Missouri
         Added by James Kunstle.
 
         Returns:
             _type_: _description_
         """
-        headers["Authorization"] = f"Client {self.client_secret}, Bearer {access_token}"
+        headers["Authorization"] = f"Client {self.client_secret}"
 
-        result = requests.post(
-            self.admin_group_names_endpoint, headers=headers, params=params
-        )
+        result = requests.get(self.admin_group_names_endpoint, headers=headers, params=params)
 
         if result.status_code == 200:
             return result.json()
 
-    def make_admin_groups_request(self, access_token, headers={}, params={}):
+    def make_admin_groups_request(self, headers={}, params={}):
         """Large parts of code written by John McGinness, University of Missouri
         Added by James Kunstle.
 
         Returns:
             _type_: _description_
         """
-        headers["Authorization"] = f"Client {self.client_secret}, Bearer {access_token}"
+        headers["Authorization"] = f"Client {self.client_secret}"
 
-        result = requests.post(
-            self.admin_groups_endpoint, headers=headers, params=params
-        )
+        result = requests.get(self.admin_groups_endpoint, headers=headers, params=params)
 
         if result.status_code == 200:
             return result.json()

--- a/pages/index/index_callbacks.py
+++ b/pages/index/index_callbacks.py
@@ -199,6 +199,15 @@ def get_augur_user_preferences(
 
     elif is_client_startup:
 
+        logging.debug("LOGIN: STARTUP - GETTING ADMIN GROUPS")
+        # try to get admin groups
+        admin_groups, admin_group_options = get_admin_groups()
+
+        no_login[4] = admin_groups
+        no_login[5] = admin_group_options
+
+        logging.debug("LOGIN: STARTUP - ADMIN GROUPS SET")
+
         if expiration and bearer_token:
             checked_bt, checked_rt = verify_previous_login_credentials(bearer_token, refresh_token, expiration)
             if not all([checked_bt, checked_rt]):

--- a/pages/index/index_layout.py
+++ b/pages/index/index_layout.py
@@ -16,9 +16,13 @@ if os.getenv("AUGUR_LOGIN_ENABLED", "False") == "True":
                 dbc.Col(
                     dbc.Nav(
                         [
-                            html.Div(
-                                id="nav-login-container",
-                                children=[],
+                            dcc.Loading(
+                                children=[
+                                    html.Div(
+                                        id="nav-login-container",
+                                        children=[],
+                                    ),
+                                ]
                             ),
                             dbc.NavItem(
                                 dbc.NavLink("Refresh Groups", id="refresh-button", disabled=True),

--- a/pages/index/login_help.py
+++ b/pages/index/login_help.py
@@ -81,7 +81,7 @@ def get_user_groups(username, bearer_token):
     return users_groups, users_group_options
 
 
-def get_admin_groups(bearer_token):
+def get_admin_groups():
     """Requests all admin-level groups from augur frontend.
 
     Args:
@@ -97,7 +97,7 @@ def get_admin_groups(bearer_token):
 
     logging.debug("ADMIN_GROUPS: GETTING NAME")
     # get name of admin account that linked 8knot to augur instance
-    admin_name = augur.make_admin_name_request(bearer_token)
+    admin_name = augur.make_admin_name_request()
     if not admin_name:
         return None, None
     name = admin_name["user"]
@@ -105,7 +105,7 @@ def get_admin_groups(bearer_token):
 
     logging.debug("ADMIN_GROUPS: GETTING GROUP NAMES")
     # get the names of the admin account's groups
-    group_names = augur.make_admin_group_names_request(bearer_token)
+    group_names = augur.make_admin_group_names_request()
     if not group_names:
         return None, None
     gnames = group_names["group_names"]
@@ -114,7 +114,7 @@ def get_admin_groups(bearer_token):
     # create an entry for each group that the admin has listed.
     for n in gnames:
         logging.debug(f"ADMIN_GROUPS: REQUESTING GROUP FOR: {n}")
-        group = augur.make_admin_groups_request(bearer_token, params={"group_name": n})
+        group = augur.make_admin_groups_request(params={"group_name": n})
 
         repo_list = group["repos"]
         logging.debug(f"ADMIN_GROUPS: GOT REPOS FOR {n}, {len(repo_list)}")


### PR DESCRIPTION
app-level defaults such as the groups that the admin user creates should be available to the user regardless of whether they have logged in.

This change moves the initial query for these groups to occur when the user first starts the application. They are also re-queried if the user signs in and requests to 'Refresh Groups' or if they restart the client from scratch.

This is a stop-gap implementation of this feature- in the future, we'll have a more refined login flow.