### PR TITLE
De-register 'Home' page of metrics pending overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Other stuff
 dictionary.dic
 tmp
+.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/pages/home/home.py
+++ b/pages/home/home.py
@@ -1,3 +1,23 @@
+"""HOMEPAGE DOCSTRING
+
+Page is pending overhaul.
+
+Single-value metrics like those currently represented aren't very useful, and feedback has
+largely been that this page should say nothing rather than mis-represent project behavior.
+These metrics currently capture the all-time behavior of a group of projects and say *something* without
+being informative.
+
+For example: {# lines added in all commits for all time} says nothing about the
+kind of contributions those lines were for, whether documentation or code. They aren't
+good proxies for churn, because they're not isolated to any period of time.
+
+Another example: {Avg. lifespan of PRs that have been merged for all time} is heavily skewed
+by events like rubber-stamp merges at the beginning of a project's life, or extremely large overhauls
+that take a long time to merge. It would be more useful to describe the IQR over time, binning the
+lifespans and considering outliers independently.
+
+Page will not be registered with Dash for the time being, replaced with a Welcome page.
+"""
 from dash import html
 import dash
 import dash_bootstrap_components as dbc
@@ -6,7 +26,8 @@ from .visualizations.pr_metrics import gc_pr_metrics
 from .visualizations.issue_metrics import gc_issue_metrics
 
 # register the page
-dash.register_page(__name__, path="/", order=1)
+
+# dash.register_page(__name__, path="/", order=1)
 
 layout = dbc.Container(
     [

--- a/pages/info/info.py
+++ b/pages/info/info.py
@@ -3,7 +3,8 @@ import dash
 import dash_bootstrap_components as dbc
 
 # register the page
-dash.register_page(__name__, path="/info", order=4)
+# Page is promoted to order=1 ahead of Home page because Home page is temporarily deactivated for overhaul.
+dash.register_page(__name__, path="/", order=1)
 
 layout = dbc.Container(
     [


### PR DESCRIPTION
Was working on #308 but I think this is a better decision in the long-run.

After having conversations about this page 3+ times, I've come to the conclusion that these 'time-agnostic-metrics' say little to nothing valuable about the projects they're representing. 

This should motivate a conversation about what 'single-number' metrics actually say something valuable; maybe we can take inspiration from Devstats and say "these are the metrics from the last {time-range}" and customize the time-range.

The following rationale is at the top of pages/home/home.py but I'm copying it here for the sake of clarity:

---
Single-value metrics like those currently represented aren't very useful, and feedback has
largely been that this page should say nothing rather than mis-represent project behavior.
These metrics currently capture the all-time behavior of a group of projects and say *something* without
being informative.

For example: {# lines added in all commits for all time} says nothing about the 
kind of contributions those lines were for, whether documentation or code. They aren't
good proxies for churn, because they're not isolated to any period of time.

Another example: {Avg. lifespan of PRs that have been merged for all time} is heavily skewed
by events like rubber-stamp merges at the beginning of a project's life, or extremely large overhauls
that take a long time to merge. It would be more useful to describe the IQR over time, binning the 
lifespans and considering outliers independently.  

Page will not be registered with Dash for the time being; to be replaced with a Welcome page.
---