### PR TITLE
Find logs from workers by changing logging level defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Other stuff
 dictionary.dic
 tmp
+.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ from dash import CeleryManager, Input, Output
 import worker_settings
 import os
 
-logging.basicConfig(format="%(asctime)s %(levelname)-8s %(message)s", level=logging.DEBUG)
+logging.basicConfig(format="%(asctime)s %(levelname)-8s %(message)s", level=logging.INFO)
 
 """CREATE CELERY TASK QUEUE AND MANAGER"""
 celery_app = Celery(
@@ -41,7 +41,6 @@ celery_manager = CeleryManager(celery_app=celery_app)
 augur = AugurManager()
 
 if os.getenv("AUGUR_LOGIN_ENABLED", "False") == "True":
-
     # make sure that parameters for Augur connection have been supplied.
     client_secret = os.getenv("AUGUR_CLIENT_SECRET", "")
     app_id = os.getenv("AUGUR_APP_ID", "")

--- a/db_manager/augur_manager.py
+++ b/db_manager/augur_manager.py
@@ -148,7 +148,7 @@ class AugurManager:
 
         self.engine = engine
 
-        logging.debug("Engine returned")
+        logging.warning("Engine returned")
         return engine
 
     def run_query(self, query_string: str) -> pd.DataFrame:
@@ -228,7 +228,7 @@ class AugurManager:
 
     def multiselect_startup(self):
 
-        logging.debug(f"MULTISELECT_STARTUP")
+        logging.warning(f"MULTISELECT_STARTUP")
 
         query_string = f"""SELECT DISTINCT
                             r.repo_git,
@@ -243,7 +243,7 @@ class AugurManager:
 
         # query for search bar entry generation
         df_search_bar = self.run_query(query_string)
-        logging.debug(f"MULTISELECT_QUERY")
+        logging.warning(f"MULTISELECT_QUERY")
 
         # create a list of dictionaries for the MultiSelect dropdown
         # component on the index page.
@@ -280,7 +280,7 @@ class AugurManager:
 
         # making first selection for the search bar
         self.initial_search_option = self.multiselect_options[0]
-        logging.debug(f"MULTISELECT_FINISHED")
+        logging.warning(f"MULTISELECT_FINISHED")
 
     def repo_git_to_id(self, git):
         """Getter method for dictionary

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,16 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile.worker
-    command: ["celery", "-A", "app:celery_app", "worker", "--loglevel=INFO", "-Q", "data"]
+    command:
+      [
+        "celery",
+        "-A",
+        "app:celery_app",
+        "worker",
+        "--loglevel=WARNING",
+        "-Q",
+        "data"
+      ]
     depends_on:
       - cache
     env_file:

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -28,4 +28,4 @@ COPY ./ /explorer/
 
 # run worker
 # CMD [ "rq", "worker", "-c", "worker_settings" ]
-CMD ["celery", "-A", "app:celery_app", "worker", "--loglevel=INFO"]
+CMD ["celery", "-A", "app:celery_app", "worker", "--loglevel=WARNING"]

--- a/pages/chaoss/visualizations/contrib_activity_cycle.py
+++ b/pages/chaoss/visualizations/contrib_activity_cycle.py
@@ -89,6 +89,7 @@ gc_contrib_activity_cycle = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -111,7 +112,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def contrib_activity_cycle_graph(repolist, interval):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=cmq, repos=repolist)
@@ -120,11 +120,11 @@ def contrib_activity_cycle_graph(repolist, interval):
         df = cache.grabm(func=cmq, repos=repolist)
 
     start = time.perf_counter()
-    logging.debug(f"{VIZ_ID}- START")
+    logging.warning(f"{VIZ_ID}- START")
 
     # test if there is data
     if df.empty:
-        logging.debug(f"{VIZ_ID} - NO DATA AVAILABLE")
+        logging.warning(f"{VIZ_ID} - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing, COULD HAVE ADDITIONAL INPUTS AND OUTPUTS
@@ -132,12 +132,11 @@ def contrib_activity_cycle_graph(repolist, interval):
 
     fig = create_figure(df, interval)
 
-    logging.debug(f"{VIZ_ID} - END - {time.perf_counter() - start}")
+    logging.warning(f"{VIZ_ID} - END - {time.perf_counter() - start}")
     return fig
 
 
 def process_data(df: pd.DataFrame, interval):
-
     # for this usecase we want the datetimes to be in their local values
     # tricking pandas to keep local values when UTC conversion is required for to_datetime
     df["author_timestamp"] = df["author_timestamp"].astype("str").str[:-6]
@@ -158,7 +157,12 @@ def process_data(df: pd.DataFrame, interval):
         df_final = df_hour.groupby(["Hour"])["Hour"].count()
     else:
         # combine the weekday values for author and committer
-        weekday = pd.concat([df["author_timestamp"].dt.day_name(), df["committer_timestamp"].dt.day_name()])
+        weekday = pd.concat(
+            [
+                df["author_timestamp"].dt.day_name(),
+                df["committer_timestamp"].dt.day_name(),
+            ]
+        )
         df_weekday = pd.DataFrame(weekday, columns=["Weekday"])
         df_final = df_weekday.groupby(["Weekday"])["Weekday"].count()
 
@@ -166,9 +170,16 @@ def process_data(df: pd.DataFrame, interval):
 
 
 def create_figure(df: pd.DataFrame, interval):
-
     column = "Weekday"
-    order = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+    order = [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+    ]
     if interval == "H":
         column = "Hour"
 

--- a/pages/chaoss/visualizations/contrib_drive_repeat.py
+++ b/pages/chaoss/visualizations/contrib_drive_repeat.py
@@ -112,6 +112,7 @@ gc_contrib_drive_repeat = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -125,7 +126,10 @@ def toggle_popover_1(n, is_open):
 
 
 # callback for dynamically changing the graph title
-@callback(Output(f"graph-title-{PAGE}-{VIZ_ID}", "children"), Input(f"graph-view-{PAGE}-{VIZ_ID}", "value"))
+@callback(
+    Output(f"graph-title-{PAGE}-{VIZ_ID}", "children"),
+    Input(f"graph-view-{PAGE}-{VIZ_ID}", "value"),
+)
 def graph_title(view):
     title = ""
     if view == "drive":
@@ -146,7 +150,6 @@ def graph_title(view):
     background=True,
 )
 def repeat_drive_by_graph(repolist, contribs, view):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=ctq, repos=repolist)
@@ -156,11 +159,11 @@ def repeat_drive_by_graph(repolist, contribs, view):
 
     # data ready.
     start = time.perf_counter()
-    logging.debug("CONTRIB_DRIVE_REPEAT_VIZ - START")
+    logging.warning("CONTRIB_DRIVE_REPEAT_VIZ - START")
 
     # test if there is data
     if df.empty:
-        logging.debug("CONTRIB DRIVE REPEAT - NO DATA AVAILABLE")
+        logging.warning("CONTRIB DRIVE REPEAT - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing
@@ -168,18 +171,17 @@ def repeat_drive_by_graph(repolist, contribs, view):
 
     # test if there is data
     if df_cont_subset.empty:
-        logging.debug("CONTRIB DRIVE REPEAT - NO DRIVE OR REPEAT DATA")
+        logging.warning("CONTRIB DRIVE REPEAT - NO DRIVE OR REPEAT DATA")
         return nodata_graph
 
     fig = create_figure(df_cont_subset)
 
-    logging.debug(f"CONTRIB_DRIVE_REPEAT_VIZ - END - {time.perf_counter() - start}")
+    logging.warning(f"CONTRIB_DRIVE_REPEAT_VIZ - END - {time.perf_counter() - start}")
 
     return fig
 
 
 def process_data(df, view, contribs):
-
     # convert to datetime objects with consistent column name
     df["created_at"] = pd.to_datetime(df["created_at"], utc=True)
     df.rename(columns={"created_at": "created"}, inplace=True)

--- a/pages/chaoss/visualizations/contributors_types_over_time.py
+++ b/pages/chaoss/visualizations/contributors_types_over_time.py
@@ -111,6 +111,7 @@ gc_contributors_over_time = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -133,7 +134,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def create_contrib_over_time_graph(repolist, contribs, interval):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=ctq, repos=repolist)
@@ -142,11 +142,11 @@ def create_contrib_over_time_graph(repolist, contribs, interval):
         df = cache.grabm(func=ctq, repos=repolist)
 
     start = time.perf_counter()
-    logging.debug("CONTRIB_DRIVE_REPEAT_VIZ - START")
+    logging.warning("CONTRIB_DRIVE_REPEAT_VIZ - START")
 
     # test if there is data
     if df.empty:
-        logging.debug("PULL REQUESTS OVER TIME - NO DATA AVAILABLE")
+        logging.warning("PULL REQUESTS OVER TIME - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing
@@ -154,7 +154,7 @@ def create_contrib_over_time_graph(repolist, contribs, interval):
 
     fig = create_figure(df_drive_repeat, interval)
 
-    logging.debug(f"CONTRIBUTIONS_OVER_TIME_VIZ - END - {time.perf_counter() - start}")
+    logging.warning(f"CONTRIBUTIONS_OVER_TIME_VIZ - END - {time.perf_counter() - start}")
     return fig
 
 

--- a/pages/chaoss/visualizations/first_time_contributions.py
+++ b/pages/chaoss/visualizations/first_time_contributions.py
@@ -55,6 +55,7 @@ gc_first_time_contributions = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -75,7 +76,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def create_first_time_contributors_graph(repolist):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=ctq, repos=repolist)
@@ -84,11 +84,11 @@ def create_first_time_contributors_graph(repolist):
         df = cache.grabm(func=ctq, repos=repolist)
 
     start = time.perf_counter()
-    logging.debug("CONTRIB_DRIVE_REPEAT_VIZ - START")
+    logging.warning("CONTRIB_DRIVE_REPEAT_VIZ - START")
 
     # test if there is data
     if df.empty:
-        logging.debug("1ST CONTRIBUTIONS - NO DATA AVAILABLE")
+        logging.warning("1ST CONTRIBUTIONS - NO DATA AVAILABLE")
         return nodata_graph, False
 
     # function for all data pre processing
@@ -96,12 +96,11 @@ def create_first_time_contributors_graph(repolist):
 
     fig = create_figure(df)
 
-    logging.debug(f"1ST_CONTRIBUTIONS_VIZ - END - {time.perf_counter() - start}")
+    logging.warning(f"1ST_CONTRIBUTIONS_VIZ - END - {time.perf_counter() - start}")
     return fig
 
 
 def process_data(df):
-
     # convert to datetime objects with consistent column name
     df["created_at"] = pd.to_datetime(df["created_at"], utc=True)
     df.rename(columns={"created_at": "created"}, inplace=True)
@@ -116,7 +115,6 @@ def process_data(df):
 
 
 def create_figure(df):
-
     # create plotly express histogram
     fig = px.histogram(df, x="created", color="Action", color_discrete_sequence=color_seq)
 

--- a/pages/company/visualizations/commit_domains.py
+++ b/pages/company/visualizations/commit_domains.py
@@ -103,6 +103,7 @@ gc_commit_domains = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -127,7 +128,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def commit_domains_graph(repolist, num, start_date, end_date):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=cq, repos=repolist)
@@ -136,11 +136,11 @@ def commit_domains_graph(repolist, num, start_date, end_date):
         df = cache.grabm(func=cq, repos=repolist)
 
     start = time.perf_counter()
-    logging.debug(f"{VIZ_ID}- START")
+    logging.warning(f"{VIZ_ID}- START")
 
     # test if there is data
     if df.empty:
-        logging.debug(f"{VIZ_ID} - NO DATA AVAILABLE")
+        logging.warning(f"{VIZ_ID} - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing, COULD HAVE ADDITIONAL INPUTS AND OUTPUTS
@@ -148,7 +148,7 @@ def commit_domains_graph(repolist, num, start_date, end_date):
 
     fig = create_figure(df)
 
-    logging.debug(f"{VIZ_ID} - END - {time.perf_counter() - start}")
+    logging.warning(f"{VIZ_ID} - END - {time.perf_counter() - start}")
     return fig
 
 
@@ -197,7 +197,6 @@ def process_data(df: pd.DataFrame, num, start_date, end_date):
 
 
 def create_figure(df: pd.DataFrame):
-
     # graph generation
     fig = px.pie(df, names="domains", values="occurrences", color_discrete_sequence=color_seq)
     fig.update_traces(

--- a/pages/company/visualizations/company_associated_activity.py
+++ b/pages/company/visualizations/company_associated_activity.py
@@ -101,6 +101,7 @@ gc_company_associated_activity = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -146,11 +147,11 @@ def compay_associated_activity_graph(repolist, num, start_date, end_date):
         df = cache.grabm(func=cmq, repos=repolist)
 
     start = time.perf_counter()
-    logging.debug(f"{VIZ_ID}- START")
+    logging.warning(f"{VIZ_ID}- START")
 
     # test if there is data
     if df.empty:
-        logging.debug(f"{VIZ_ID} - NO DATA AVAILABLE")
+        logging.warning(f"{VIZ_ID} - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing, COULD HAVE ADDITIONAL INPUTS AND OUTPUTS
@@ -158,12 +159,11 @@ def compay_associated_activity_graph(repolist, num, start_date, end_date):
 
     fig = create_figure(df)
 
-    logging.debug(f"{VIZ_ID} - END - {time.perf_counter() - start}")
+    logging.warning(f"{VIZ_ID} - END - {time.perf_counter() - start}")
     return fig
 
 
 def process_data(df: pd.DataFrame, num, start_date, end_date):
-
     # convert to datetime objects rather than strings
     df["created"] = pd.to_datetime(df["created"], utc=True)
 
@@ -206,7 +206,6 @@ def process_data(df: pd.DataFrame, num, start_date, end_date):
 
 
 def create_figure(df: pd.DataFrame):
-
     # graph generation
     fig = px.bar(df, x="domains", y="occurrences", color_discrete_sequence=color_seq)
     fig.update_xaxes(rangeslider_visible=True, range=[-0.5, 15])

--- a/pages/company/visualizations/company_core_contributors.py
+++ b/pages/company/visualizations/company_core_contributors.py
@@ -122,6 +122,7 @@ gc_company_core_contributors = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -147,7 +148,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def compay_associated_activity_graph(repolist, contributions, contributors, start_date, end_date):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=cmq, repos=repolist)
@@ -156,11 +156,11 @@ def compay_associated_activity_graph(repolist, contributions, contributors, star
         df = cache.grabm(func=cmq, repos=repolist)
 
     start = time.perf_counter()
-    logging.debug(f"{VIZ_ID}- START")
+    logging.warning(f"{VIZ_ID}- START")
 
     # test if there is data
     if df.empty:
-        logging.debug(f"{VIZ_ID} - NO DATA AVAILABLE")
+        logging.warning(f"{VIZ_ID} - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing, COULD HAVE ADDITIONAL INPUTS AND OUTPUTS
@@ -168,12 +168,11 @@ def compay_associated_activity_graph(repolist, contributions, contributors, star
 
     fig = create_figure(df)
 
-    logging.debug(f"{VIZ_ID} - END - {time.perf_counter() - start}")
+    logging.warning(f"{VIZ_ID} - END - {time.perf_counter() - start}")
     return fig
 
 
 def process_data(df: pd.DataFrame, contributions, contributors, start_date, end_date):
-
     # convert to datetime objects rather than strings
     df["created"] = pd.to_datetime(df["created"], utc=True)
 
@@ -223,7 +222,6 @@ def process_data(df: pd.DataFrame, contributions, contributors, start_date, end_
 
 
 def create_figure(df: pd.DataFrame):
-
     # graph generation
     fig = px.bar(df, x="domains", y="contributors", color_discrete_sequence=color_seq)
     fig.update_xaxes(rangeslider_visible=True, range=[-0.5, 15])

--- a/pages/company/visualizations/gh_company_affiliation.py
+++ b/pages/company/visualizations/gh_company_affiliation.py
@@ -100,6 +100,7 @@ gc_gh_company_affiliation = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -124,7 +125,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def gh_company_affiliation_graph(repolist, num, start_date, end_date):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=cmq, repos=repolist)
@@ -133,11 +133,11 @@ def gh_company_affiliation_graph(repolist, num, start_date, end_date):
         df = cache.grabm(func=cmq, repos=repolist)
 
     start = time.perf_counter()
-    logging.debug(f"{VIZ_ID}- START")
+    logging.warning(f"{VIZ_ID}- START")
 
     # test if there is data
     if df.empty:
-        logging.debug(f"{VIZ_ID} - NO DATA AVAILABLE")
+        logging.warning(f"{VIZ_ID} - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing, COULD HAVE ADDITIONAL INPUTS AND OUTPUTS
@@ -145,7 +145,7 @@ def gh_company_affiliation_graph(repolist, num, start_date, end_date):
 
     fig = create_figure(df)
 
-    logging.debug(f"{VIZ_ID} - END - {time.perf_counter() - start}")
+    logging.warning(f"{VIZ_ID} - END - {time.perf_counter() - start}")
     return fig
 
 
@@ -225,9 +225,13 @@ def fuzzy_match(df, name):
 
 
 def create_figure(df: pd.DataFrame):
-
     # graph generation
-    fig = px.pie(df, names="company_name", values="contribution_count", color_discrete_sequence=color_seq)
+    fig = px.pie(
+        df,
+        names="company_name",
+        values="contribution_count",
+        color_discrete_sequence=color_seq,
+    )
     fig.update_traces(
         textposition="inside",
         textinfo="percent+label",

--- a/pages/company/visualizations/unqiue_domains.py
+++ b/pages/company/visualizations/unqiue_domains.py
@@ -97,6 +97,7 @@ gc_unique_domains = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -121,7 +122,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def unique_domains_graph(repolist, num, start_date, end_date):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=cmq, repos=repolist)
@@ -130,11 +130,11 @@ def unique_domains_graph(repolist, num, start_date, end_date):
         df = cache.grabm(func=cmq, repos=repolist)
 
     start = time.perf_counter()
-    logging.debug(f"{VIZ_ID}- START")
+    logging.warning(f"{VIZ_ID}- START")
 
     # test if there is data
     if df.empty:
-        logging.debug(f"{VIZ_ID} - NO DATA AVAILABLE")
+        logging.warning(f"{VIZ_ID} - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing, COULD HAVE ADDITIONAL INPUTS AND OUTPUTS
@@ -142,12 +142,11 @@ def unique_domains_graph(repolist, num, start_date, end_date):
 
     fig = create_figure(df)
 
-    logging.debug(f"{VIZ_ID} - END - {time.perf_counter() - start}")
+    logging.warning(f"{VIZ_ID} - END - {time.perf_counter() - start}")
     return fig
 
 
 def process_data(df: pd.DataFrame, num, start_date, end_date):
-
     # convert to datetime objects rather than strings
     df["created"] = pd.to_datetime(df["created"], utc=True)
 
@@ -190,7 +189,6 @@ def process_data(df: pd.DataFrame, num, start_date, end_date):
 
 
 def create_figure(df: pd.DataFrame):
-
     # graph generation
     fig = px.pie(df, names="domains", values="occurences", color_discrete_sequence=color_seq)
     fig.update_traces(

--- a/pages/index/index_layout.py
+++ b/pages/index/index_layout.py
@@ -9,7 +9,7 @@ import logging
 # if param doesn't exist, default to False. Otherwise, use the param's booly value.
 # this determines if the log in option will be shown or not
 if os.getenv("AUGUR_LOGIN_ENABLED", "False") == "True":
-    logging.debug("LOGIN ENABLED")
+    logging.warning("LOGIN ENABLED")
     login_navbar = [
         dbc.Row(
             [
@@ -56,7 +56,7 @@ if os.getenv("AUGUR_LOGIN_ENABLED", "False") == "True":
         ),
     ]
 else:
-    logging.debug("LOGIN DISABLED")
+    logging.warning("LOGIN DISABLED")
     login_navbar = [html.Div()]
 
 # navbar for top of screen

--- a/pages/index/login_help.py
+++ b/pages/index/login_help.py
@@ -19,9 +19,7 @@ def verify_previous_login_credentials(bearer_token, refresh_token, expiration):
     """
 
     if expiration != "" and bearer_token != "":
-
         if datetime.now() < datetime.strptime(expiration, "%Y-%m-%dT%H:%M:%S.%f"):
-
             return bearer_token, refresh_token
 
         # TODO: handle refresh if token is past expiration.
@@ -54,7 +52,6 @@ def get_user_groups(username, bearer_token):
 
     # each of the augur user groups
     for entry in g:
-
         # group has one key- the name.
         group_name: str = list(entry.keys())[0]
 
@@ -95,29 +92,29 @@ def get_admin_groups():
     admin_groups = {}
     admin_group_options = []
 
-    logging.debug("ADMIN_GROUPS: GETTING NAME")
+    logging.warning("ADMIN_GROUPS: GETTING NAME")
     # get name of admin account that linked 8knot to augur instance
     admin_name = augur.make_admin_name_request()
     if not admin_name:
         return None, None
     name = admin_name["user"]
-    logging.debug(f"ADMIN_GROUPS: NAME IS {name}")
+    logging.warning(f"ADMIN_GROUPS: NAME IS {name}")
 
-    logging.debug("ADMIN_GROUPS: GETTING GROUP NAMES")
+    logging.warning("ADMIN_GROUPS: GETTING GROUP NAMES")
     # get the names of the admin account's groups
     group_names = augur.make_admin_group_names_request()
     if not group_names:
         return None, None
     gnames = group_names["group_names"]
-    logging.debug(f"ADMIN_GROUPS: # NAMES: {len(gnames)}")
+    logging.warning(f"ADMIN_GROUPS: # NAMES: {len(gnames)}")
 
     # create an entry for each group that the admin has listed.
     for n in gnames:
-        logging.debug(f"ADMIN_GROUPS: REQUESTING GROUP FOR: {n}")
+        logging.warning(f"ADMIN_GROUPS: REQUESTING GROUP FOR: {n}")
         group = augur.make_admin_groups_request(params={"group_name": n})
 
         repo_list = group["repos"]
-        logging.debug(f"ADMIN_GROUPS: GOT REPOS FOR {n}, {len(repo_list)}")
+        logging.warning(f"ADMIN_GROUPS: GOT REPOS FOR {n}, {len(repo_list)}")
 
         # need to prepend https:// because repos in repo_list don't include
         # that part of the URL.
@@ -153,7 +150,6 @@ def parse_repolist(repo_list, prepend_to_url=""):
 
     ids = []
     for repo in repo_list:
-
         if "repo_git" in repo.keys():
             # user groups have URL under 'repo_git' key
             repo_url = repo.get("repo_git")

--- a/pages/overview/visualizations/active_drifting_contributors.py
+++ b/pages/overview/visualizations/active_drifting_contributors.py
@@ -136,6 +136,7 @@ gc_active_drifting_contributors = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -160,7 +161,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def active_drifting_contributors_graph(repolist, interval, drift_interval, away_interval):
-
     # conditional for the intervals to be valid options
     if drift_interval is None or away_interval is None:
         return dash.no_update, dash.no_update
@@ -175,12 +175,12 @@ def active_drifting_contributors_graph(repolist, interval, drift_interval, away_
         time.sleep(1.0)
         df = cache.grabm(func=ctq, repos=repolist)
 
-    logging.debug(f"ACTIVE_DRIFTING_CONTRIBUTOR_GROWTH_VIZ - START")
+    logging.warning(f"ACTIVE_DRIFTING_CONTRIBUTOR_GROWTH_VIZ - START")
     start = time.perf_counter()
 
     # test if there is data
     if df.empty:
-        logging.debug("PULL REQUEST STALENESS - NO DATA AVAILABLE")
+        logging.warning("PULL REQUEST STALENESS - NO DATA AVAILABLE")
         return nodata_graph, False
 
     # function for all data pre processing
@@ -188,12 +188,11 @@ def active_drifting_contributors_graph(repolist, interval, drift_interval, away_
 
     fig = create_figure(df_status, interval)
 
-    logging.debug(f"ACTIVE_DRIFTING_CONTRIBUTOR_GROWTH_VIZ - END - {time.perf_counter() - start}")
+    logging.warning(f"ACTIVE_DRIFTING_CONTRIBUTOR_GROWTH_VIZ - END - {time.perf_counter() - start}")
     return fig, False
 
 
 def process_data(df: pd.DataFrame, interval, drift_interval, away_interval):
-
     # convert to datetime objects with consistent column name
     df["created_at"] = pd.to_datetime(df["created_at"], utc=True)
     df.rename(columns={"created_at": "created"}, inplace=True)
@@ -229,7 +228,6 @@ def process_data(df: pd.DataFrame, interval, drift_interval, away_interval):
 
 
 def create_figure(df_status: pd.DataFrame, interval):
-
     # time values for graph
     x_r, x_name, hover, period = get_graph_time_values(interval)
 
@@ -288,7 +286,6 @@ def create_figure(df_status: pd.DataFrame, interval):
 
 
 def get_active_drifting_away_up_to(df, date, drift_interval, away_interval):
-
     # drop rows that are more recent than the date limit
     df_lim = df[df["created"] <= date]
 

--- a/pages/overview/visualizations/commits_over_time.py
+++ b/pages/overview/visualizations/commits_over_time.py
@@ -87,6 +87,7 @@ gc_commits_over_time = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -109,7 +110,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def commits_over_time_graph(repolist, interval):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=cmq, repos=repolist)
@@ -119,11 +119,11 @@ def commits_over_time_graph(repolist, interval):
 
     # data ready.
     start = time.perf_counter()
-    logging.debug("COMMITS_OVER_TIME_VIZ - START")
+    logging.warning("COMMITS_OVER_TIME_VIZ - START")
 
     # test if there is data
     if df.empty:
-        logging.debug("COMMITS OVER TIME - NO DATA AVAILABLE")
+        logging.warning("COMMITS OVER TIME - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing
@@ -131,12 +131,11 @@ def commits_over_time_graph(repolist, interval):
 
     fig = create_figure(df_created, interval)
 
-    logging.debug(f"COMMITS_OVER_TIME_VIZ - END - {time.perf_counter() - start}")
+    logging.warning(f"COMMITS_OVER_TIME_VIZ - END - {time.perf_counter() - start}")
     return fig
 
 
 def process_data(df: pd.DataFrame, interval):
-
     # convert to datetime objects with consistent column name
     # incoming value should be a posix integer.
     df["date"] = pd.to_datetime(df["date"], utc=True)
@@ -164,7 +163,6 @@ def process_data(df: pd.DataFrame, interval):
 
 
 def create_figure(df_created: pd.DataFrame, interval):
-
     # time values for graph
     x_r, x_name, hover, period = get_graph_time_values(interval)
 

--- a/pages/overview/visualizations/issue_staleness.py
+++ b/pages/overview/visualizations/issue_staleness.py
@@ -138,6 +138,7 @@ gc_issue_staleness = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -162,7 +163,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def new_staling_issues_graph(repolist, interval, staling_interval, stale_interval):
-
     # conditional for the intervals to be valid options
     if staling_interval > stale_interval:
         return dash.no_update, True
@@ -178,11 +178,11 @@ def new_staling_issues_graph(repolist, interval, staling_interval, stale_interva
         df = cache.grabm(func=iq, repos=repolist)
 
     start = time.perf_counter()
-    logging.debug("ISSUES STALENESS - START")
+    logging.warning("ISSUES STALENESS - START")
 
     # test if there is data
     if df.empty:
-        logging.debug("ISSUE STALENESS - NO DATA AVAILABLE")
+        logging.warning("ISSUE STALENESS - NO DATA AVAILABLE")
         return nodata_graph, False
 
     # function for all data pre processing
@@ -190,12 +190,11 @@ def new_staling_issues_graph(repolist, interval, staling_interval, stale_interva
 
     fig = create_figure(df_status, interval)
 
-    logging.debug(f"ISSUE STALENESS - END - {time.perf_counter() - start}")
+    logging.warning(f"ISSUE STALENESS - END - {time.perf_counter() - start}")
     return fig, False
 
 
 def process_data(df: pd.DataFrame, interval, staling_interval, stale_interval):
-
     # convert to datetime objects rather than strings
     df["created"] = pd.to_datetime(df["created"], utc=True)
     df["closed"] = pd.to_datetime(df["closed"], utc=True)
@@ -232,7 +231,6 @@ def process_data(df: pd.DataFrame, interval, staling_interval, stale_interval):
 
 
 def create_figure(df_status: pd.DataFrame, interval):
-
     # time values for graph
     x_r, x_name, hover, period = get_graph_time_values(interval)
 
@@ -291,7 +289,6 @@ def create_figure(df_status: pd.DataFrame, interval):
 
 
 def get_new_staling_stale_up_to(df, date, staling_interval, stale_interval):
-
     # drop rows that are more recent than the date limit
     df_created = df[df["created"] <= date]
 

--- a/pages/overview/visualizations/issues_over_time.py
+++ b/pages/overview/visualizations/issues_over_time.py
@@ -89,6 +89,7 @@ gc_issues_over_time = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -111,7 +112,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def issues_over_time_graph(repolist, interval):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=iq, repos=repolist)
@@ -121,11 +121,11 @@ def issues_over_time_graph(repolist, interval):
 
     # data ready.
     start = time.perf_counter()
-    logging.debug("ISSUES OVER TIME - START")
+    logging.warning("ISSUES OVER TIME - START")
 
     # test if there is data
     if df.empty:
-        logging.debug("ISSUES OVER TIME - NO DATA AVAILABLE")
+        logging.warning("ISSUES OVER TIME - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing
@@ -133,13 +133,12 @@ def issues_over_time_graph(repolist, interval):
 
     fig = create_figure(df_created, df_closed, df_open, interval)
 
-    logging.debug(f"ISSUES_OVER_TIME_VIZ - END - {time.perf_counter() - start}")
+    logging.warning(f"ISSUES_OVER_TIME_VIZ - END - {time.perf_counter() - start}")
 
     return fig
 
 
 def process_data(df: pd.DataFrame, interval):
-
     # convert to datetime objects rather than strings
     df["created"] = pd.to_datetime(df["created"], utc=True)
     df["closed"] = pd.to_datetime(df["closed"], utc=True)
@@ -198,7 +197,6 @@ def process_data(df: pd.DataFrame, interval):
 
 
 def create_figure(df_created: pd.DataFrame, df_closed: pd.DataFrame, df_open: pd.DataFrame, interval):
-
     # time values for graph
     x_r, x_name, hover, period = get_graph_time_values(interval)
 
@@ -252,7 +250,6 @@ def create_figure(df_created: pd.DataFrame, df_closed: pd.DataFrame, df_open: pd
 
 # for each day, this function calculates the amount of open issues
 def get_open(df, date):
-
     # drop rows that are more recent than the date limit
     df_lim = df[df["created"] <= date]
 

--- a/pages/overview/visualizations/new_contributor.py
+++ b/pages/overview/visualizations/new_contributor.py
@@ -125,7 +125,6 @@ def graph_title(view):
     background=True,
 )
 def new_contributor_graph(repolist, interval):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=ctq, repos=repolist)
@@ -133,12 +132,12 @@ def new_contributor_graph(repolist, interval):
         time.sleep(1.0)
         df = cache.grabm(func=ctq, repos=repolist)
 
-    logging.debug("TOTAL_CONTRIBUTOR_GROWTH_VIZ - START")
+    logging.warning("TOTAL_CONTRIBUTOR_GROWTH_VIZ - START")
     start = time.perf_counter()
 
     # test if there is data
     if df.empty:
-        logging.debug("TOTAL_CONTRIBUTOR_GROWTH_VIZ - NO DATA AVAILABLE")
+        logging.warning("TOTAL_CONTRIBUTOR_GROWTH_VIZ - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing
@@ -146,12 +145,11 @@ def new_contributor_graph(repolist, interval):
 
     fig = create_figure(df, df_contribs, interval)
 
-    logging.debug(f"TOTAL_CONTRIBUTOR_GROWTH_VIZ - END - {time.perf_counter() - start}")
+    logging.warning(f"TOTAL_CONTRIBUTOR_GROWTH_VIZ - END - {time.perf_counter() - start}")
     return fig
 
 
 def process_data(df, interval):
-
     # convert to datetime objects with consistent column name
     df["created_at"] = pd.to_datetime(df["created_at"], utc=True)
     df.rename(columns={"created_at": "created"}, inplace=True)
@@ -195,7 +193,6 @@ def process_data(df, interval):
 
 
 def create_figure(df, df_contribs, interval):
-
     # time values for graph
     x_r, x_name, hover, period = get_graph_time_values(interval)
 

--- a/pages/overview/visualizations/pr_over_time.py
+++ b/pages/overview/visualizations/pr_over_time.py
@@ -90,6 +90,7 @@ gc_pr_over_time = dbc.Card(
     ],
 )
 
+
 # formatting for graph generation
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -112,7 +113,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def prs_over_time_graph(repolist, interval):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=prq, repos=repolist)
@@ -122,11 +122,11 @@ def prs_over_time_graph(repolist, interval):
 
     # data ready.
     start = time.perf_counter()
-    logging.debug("PULL REQUESTS OVER TIME - START")
+    logging.warning("PULL REQUESTS OVER TIME - START")
 
     # test if there is data
     if df.empty:
-        logging.debug("PULL REQUESTS OVER TIME - NO DATA AVAILABLE")
+        logging.warning("PULL REQUESTS OVER TIME - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing
@@ -134,13 +134,12 @@ def prs_over_time_graph(repolist, interval):
 
     fig = create_figure(df_created, df_closed_merged, df_open, interval)
 
-    logging.debug(f"PRS_OVER_TIME_VIZ - END - {time.perf_counter() - start}")
+    logging.warning(f"PRS_OVER_TIME_VIZ - END - {time.perf_counter() - start}")
 
     return fig
 
 
 def process_data(df: pd.DataFrame, interval):
-
     # convert dates to datetime objects rather than strings
     df["created"] = pd.to_datetime(df["created"], utc=True)
     df["merged"] = pd.to_datetime(df["merged"], utc=True)
@@ -217,7 +216,6 @@ def create_figure(
     df_open: pd.DataFrame,
     interval,
 ):
-
     # time values for graph
     x_r, x_name, hover, period = get_graph_time_values(interval)
 
@@ -281,7 +279,6 @@ def create_figure(
 
 # for each day, this function calculates the amount of open prs
 def get_open(df, date):
-
     # drop rows that are more recent than the date limit
     df_created = df[df["created"] <= date]
 

--- a/pages/overview/visualizations/pr_staleness.py
+++ b/pages/overview/visualizations/pr_staleness.py
@@ -136,6 +136,7 @@ gc_pr_staleness = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -160,7 +161,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def new_staling_prs_graph(repolist, interval, staling_interval, stale_interval):
-
     # conditional for the intervals to be valid options
     if staling_interval > stale_interval:
         return dash.no_update, True
@@ -176,11 +176,11 @@ def new_staling_prs_graph(repolist, interval, staling_interval, stale_interval):
         df = cache.grabm(func=prq, repos=repolist)
 
     start = time.perf_counter()
-    logging.debug("PULL REQUEST STALENESS - START")
+    logging.warning("PULL REQUEST STALENESS - START")
 
     # test if there is data
     if df.empty:
-        logging.debug("PULL REQUEST STALENESS  - NO DATA AVAILABLE")
+        logging.warning("PULL REQUEST STALENESS  - NO DATA AVAILABLE")
         return nodata_graph, False
 
     # function for all data pre processing
@@ -188,12 +188,11 @@ def new_staling_prs_graph(repolist, interval, staling_interval, stale_interval):
 
     fig = create_figure(df_status, interval)
 
-    logging.debug(f"PULL REQUEST STALENESS - END - {time.perf_counter() - start}")
+    logging.warning(f"PULL REQUEST STALENESS - END - {time.perf_counter() - start}")
     return fig, False
 
 
 def process_data(df: pd.DataFrame, interval, staling_interval, stale_interval):
-
     # convert to datetime objects rather than strings
     df["created"] = pd.to_datetime(df["created"], utc=True)
     df["merged"] = pd.to_datetime(df["merged"], utc=True)
@@ -231,7 +230,6 @@ def process_data(df: pd.DataFrame, interval, staling_interval, stale_interval):
 
 
 def create_figure(df_status: pd.DataFrame, interval):
-
     # time values for graph
     x_r, x_name, hover, period = get_graph_time_values(interval)
 
@@ -290,7 +288,6 @@ def create_figure(df_status: pd.DataFrame, interval):
 
 
 def get_new_staling_stale_up_to(df, date, staling_interval, stale_interval):
-
     # drop rows that are more recent than the date limit
     df_created = df[df["created"] <= date]
 

--- a/pages/visualization_template/viz_template.py
+++ b/pages/visualization_template/viz_template.py
@@ -153,6 +153,7 @@ gc_VISUALIZATION = dbc.Card(
     ],
 )
 
+
 # callback for graph info popover
 @callback(
     Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
@@ -178,7 +179,6 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def NAME_OF_VISUALIZATION_graph(repolist, interval):
-
     # wait for data to asynchronously download and become available.
     cache = cm()
     df = cache.grabm(func=QUERY_INITIALS, repos=repolist)
@@ -187,11 +187,11 @@ def NAME_OF_VISUALIZATION_graph(repolist, interval):
         df = cache.grabm(func=QUERY_INITIALS, repos=repolist)
 
     start = time.perf_counter()
-    logging.debug(f"{VIZ_ID}- START")
+    logging.warning(f"{VIZ_ID}- START")
 
     # test if there is data
     if df.empty:
-        logging.debug(f"{VIZ_ID} - NO DATA AVAILABLE")
+        logging.warning(f"{VIZ_ID} - NO DATA AVAILABLE")
         return nodata_graph
 
     # function for all data pre processing, COULD HAVE ADDITIONAL INPUTS AND OUTPUTS
@@ -199,7 +199,7 @@ def NAME_OF_VISUALIZATION_graph(repolist, interval):
 
     fig = create_figure(df, interval)
 
-    logging.debug(f"{VIZ_ID} - END - {time.perf_counter() - start}")
+    logging.warning(f"{VIZ_ID} - END - {time.perf_counter() - start}")
     return fig
 
 
@@ -221,7 +221,6 @@ def process_data(df: pd.DataFrame, interval):
 
 
 def create_figure(df: pd.DataFrame, interval):
-
     # time values for graph
     x_r, x_name, hover, period = get_graph_time_values(interval)
 

--- a/queries/commits_query.py
+++ b/queries/commits_query.py
@@ -30,7 +30,7 @@ def commits_query(self, dbmc, repos):
     --------
         dict: Results from SQL query, interpreted from pd.to_dict('records')
     """
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - START")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - START")
 
     if len(repos) == 0:
         return None
@@ -99,5 +99,5 @@ def commits_query(self, dbmc, repos):
         datas=pic,
     )
 
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - END")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - END")
     return ack

--- a/queries/company_query.py
+++ b/queries/company_query.py
@@ -30,7 +30,7 @@ def company_query(self, dbmc, repos):
     --------
         dict: Results from SQL query, interpreted from pd.to_dict('records')
     """
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - START")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - START")
 
     if len(repos) == 0:
         return None
@@ -99,5 +99,5 @@ def company_query(self, dbmc, repos):
         datas=pic,
     )
 
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - END")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - END")
     return ack

--- a/queries/contributors_query.py
+++ b/queries/contributors_query.py
@@ -30,7 +30,7 @@ def contributors_query(self, dbmc, repos):
     --------
         dict: Results from SQL query, interpreted from pd.to_dict('records')
     """
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - START")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - START")
 
     if len(repos) == 0:
         return None
@@ -95,6 +95,6 @@ def contributors_query(self, dbmc, repos):
         repos=repos,
         datas=pic,
     )
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - END")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - END")
 
     return ack

--- a/queries/issues_query.py
+++ b/queries/issues_query.py
@@ -31,7 +31,7 @@ def issues_query(self, dbmc, repos):
         dict: Results from SQL query, interpreted from pd.to_dict('records')
     """
 
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - START")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - START")
 
     if len(repos) == 0:
         return None
@@ -54,7 +54,7 @@ def issues_query(self, dbmc, repos):
                         r.repo_id in ({str(repos)[1:-1]})
                     """
 
-    # logging.debug(query_string)
+    # logging.warning(query_string)
 
     # create database connection, load config, execute query above.
     dbm = AugurManager()
@@ -102,5 +102,5 @@ def issues_query(self, dbmc, repos):
         datas=pic,
     )
 
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - END")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - END")
     return ack

--- a/queries/prs_query.py
+++ b/queries/prs_query.py
@@ -30,7 +30,7 @@ def prs_query(self, dbmc, repos):
     --------
         dict: Results from SQL query, interpreted from pd.to_dict('records')
     """
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - START")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - START")
 
     if len(repos) == 0:
         return None
@@ -95,5 +95,5 @@ def prs_query(self, dbmc, repos):
         datas=pic,
     )
 
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - END")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - END")
     return ack

--- a/queries/query_template.py
+++ b/queries/query_template.py
@@ -42,7 +42,7 @@ def NAME_query(self, dbmc, repos):
     --------
         dict: Results from SQL query, interpreted from pd.to_dict('records')
     """
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - START")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - START")
 
     if len(repos) == 0:
         return None
@@ -101,6 +101,6 @@ def NAME_query(self, dbmc, repos):
         repos=repos,
         datas=pic,
     )
-    logging.debug(f"{QUERY_NAME}_DATA_QUERY - END")
+    logging.warning(f"{QUERY_NAME}_DATA_QUERY - END")
 
     return ack


### PR DESCRIPTION
Fixes #252 

Logs from worker results were being hidden because they were at
DEBUG level rather than INFO level. This change promotes logs
generated by app functionality from L1 to L3, which supercedes
logs of L1 and L2 generated by the application framework.

Unfortunately, L3 is called 'Warning' which is too grave of an
intention for this change. That being said, we'll adopt the convention
that L3 logs, for the time being, are standard-functionality logs
because the TRACE logging level, old L1, has been deprecated.

TRACE = L1 (deprecated)
DEBUG = L2 (now L1)
INFO = L3 (now L2, which we want to be using)
WARNING = L4 (now L3, level that we're currenting using)
...
