### PR TITLE
removes use of pconfig, purely environment

### DIFF
--- a/pages/index/index_callbacks.py
+++ b/pages/index/index_callbacks.py
@@ -456,7 +456,7 @@ def run_queries(repos):
         not_ready = [r for r in repos if cache.exists(f, r) != 1]
 
         # add job to queue
-        j = f.apply_async(args=(augur.package_config(), not_ready), queue="data")
+        j = f.apply_async(args=[not_ready], queue="data")
 
         # add job promise to local promise list
         jobs.append(j)

--- a/queries/commits_query.py
+++ b/queries/commits_query.py
@@ -5,6 +5,10 @@ import pandas as pd
 from cache_manager.cache_manager import CacheManager as cm
 import io
 import datetime as dt
+from sqlalchemy.exc import SQLAlchemyError
+
+# DEBUGGING
+import os
 
 QUERY_NAME = "COMMITS"
 
@@ -16,15 +20,13 @@ QUERY_NAME = "COMMITS"
     retry_kwargs={"max_retries": 5},
     retry_jitter=True,
 )
-def commits_query(self, dbmc, repos):
+def commits_query(self, repos):
     """
     (Worker Query)
     Executes SQL query against Augur database for commit data.
 
     Args:
     -----
-        dbmc (AugurManager): Handles connection to Augur database, executes queries and returns results.
-
         repo_ids ([str]): repos that SQL query is executed on.
 
     Returns:
@@ -61,9 +63,18 @@ def commits_query(self, dbmc, repos):
                         c.repo_id in ({str(repos)[1:-1]})
                     """
 
-    # create database connection, load config, execute query above.
-    dbm = AugurManager()
-    dbm.load_pconfig(dbmc)
+    try:
+        dbm = AugurManager()
+        engine = dbm.get_engine()
+    except KeyError:
+        # noack, data wasn't successfully set.
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - INCOMPLETE ENVIRONMENT")
+        return False
+    except SQLAlchemyError:
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - COULDN'T CONNECT TO DB")
+        # allow retry via Celery rules.
+        raise SQLAlchemyError("DBConnect failed")
+
     df = dbm.run_query(query_string)
 
     # change to compatible type and remove all data that has been incorrectly formated

--- a/queries/company_query.py
+++ b/queries/company_query.py
@@ -5,6 +5,7 @@ import pandas as pd
 from cache_manager.cache_manager import CacheManager as cm
 import io
 import datetime as dt
+from sqlalchemy.exc import SQLAlchemyError
 
 QUERY_NAME = "COMPANY"
 
@@ -16,15 +17,13 @@ QUERY_NAME = "COMPANY"
     retry_kwargs={"max_retries": 5},
     retry_jitter=True,
 )
-def company_query(self, dbmc, repos):
+def company_query(self, repos):
     """
     (Worker Query)
     Executes SQL query against Augur database for company affiliation data.
 
     Args:
     -----
-        dbmc (AugurManager): Handles connection to Augur database, executes queries and returns results.
-
         repo_ids ([str]): repos that SQL query is executed on.
 
     Returns:
@@ -56,9 +55,19 @@ def company_query(self, dbmc, repos):
                         c.repo_id in({str(repos)[1:-1]})
                     GROUP BY c.cntrb_id, c.created_at, c.repo_id, c.login, c.action, c.rank, con.cntrb_company
                     """
-    # create database connection, load config, execute query above.
-    dbm = AugurManager()
-    dbm.load_pconfig(dbmc)
+
+    try:
+        dbm = AugurManager()
+        engine = dbm.get_engine()
+    except KeyError:
+        # noack, data wasn't successfully set.
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - INCOMPLETE ENVIRONMENT")
+        return False
+    except SQLAlchemyError:
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - COULDN'T CONNECT TO DB")
+        # allow retry via Celery rules.
+        raise SQLAlchemyError("DBConnect failed")
+
     df = dbm.run_query(query_string)
 
     df["cntrb_id"] = df["cntrb_id"].astype(str)

--- a/queries/contributors_query.py
+++ b/queries/contributors_query.py
@@ -5,6 +5,7 @@ from app import celery_app
 from cache_manager.cache_manager import CacheManager as cm
 import io
 import datetime as dt
+from sqlalchemy.exc import SQLAlchemyError
 
 QUERY_NAME = "CONTRIBUTOR"
 
@@ -16,15 +17,13 @@ QUERY_NAME = "CONTRIBUTOR"
     retry_kwargs={"max_retries": 5},
     retry_jitter=True,
 )
-def contributors_query(self, dbmc, repos):
+def contributors_query(self, repos):
     """
     (Worker Query)
     Executes SQL query against Augur database for contributor data.
 
     Args:
     -----
-        dbmc (AugurManager): Handles connection to Augur database, executes queries and returns results.
-
         repo_ids ([str]): repos that SQL query is executed on.
 
     Returns:
@@ -50,9 +49,18 @@ def contributors_query(self, dbmc, repos):
                         repo_id in ({str(repos)[1:-1]})
                 """
 
-    # create database connection, load config, execute query above.
-    dbm = AugurManager()
-    dbm.load_pconfig(dbmc)
+    try:
+        dbm = AugurManager()
+        engine = dbm.get_engine()
+    except KeyError:
+        # noack, data wasn't successfully set.
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - INCOMPLETE ENVIRONMENT")
+        return False
+    except SQLAlchemyError:
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - COULDN'T CONNECT TO DB")
+        # allow retry via Celery rules.
+        raise SQLAlchemyError("DBConnect failed")
+
     df = dbm.run_query(query_string)
 
     # update column values

--- a/queries/issues_query.py
+++ b/queries/issues_query.py
@@ -5,6 +5,7 @@ from cache_manager.cache_manager import CacheManager as cm
 import pandas as pd
 import io
 import datetime as dt
+from sqlalchemy.exc import SQLAlchemyError
 
 QUERY_NAME = "ISSUE"
 
@@ -16,15 +17,13 @@ QUERY_NAME = "ISSUE"
     retry_kwargs={"max_retries": 5},
     retry_jitter=True,
 )
-def issues_query(self, dbmc, repos):
+def issues_query(self, repos):
     """
     (Worker Query)
     Executes SQL query against Augur database for issue data.
 
     Args:
     -----
-        dbmc (AugurManager): Handles connection to Augur database, executes queries and returns results.
-
         repo_ids ([str]): repos that SQL query is executed on.
 
     Returns:
@@ -55,11 +54,17 @@ def issues_query(self, dbmc, repos):
                         r.repo_id in ({str(repos)[1:-1]})
                     """
 
-    # logging.warning(query_string)
-
-    # create database connection, load config, execute query above.
-    dbm = AugurManager()
-    dbm.load_pconfig(dbmc)
+    try:
+        dbm = AugurManager()
+        engine = dbm.get_engine()
+    except KeyError:
+        # noack, data wasn't successfully set.
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - INCOMPLETE ENVIRONMENT")
+        return False
+    except SQLAlchemyError:
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - COULDN'T CONNECT TO DB")
+        # allow retry via Celery rules.
+        raise SQLAlchemyError("DBConnect failed")
 
     df = dbm.run_query(query_string)
 

--- a/queries/prs_query.py
+++ b/queries/prs_query.py
@@ -5,6 +5,7 @@ from app import celery_app
 from cache_manager.cache_manager import CacheManager as cm
 import io
 import datetime as dt
+from sqlalchemy.exc import SQLAlchemyError
 
 QUERY_NAME = "PR"
 
@@ -16,15 +17,13 @@ QUERY_NAME = "PR"
     retry_kwargs={"max_retries": 5},
     retry_jitter=True,
 )
-def prs_query(self, dbmc, repos):
+def prs_query(self, repos):
     """
     (Worker Query)
     Executes SQL query against Augur database for pull request data.
 
     Args:
     -----
-        dbmc (AugurManager): Handles connection to Augur database, executes queries and returns results.
-
         repo_ids ([str]): repos that SQL query is executed on.
 
     Returns:
@@ -53,9 +52,18 @@ def prs_query(self, dbmc, repos):
                         r.repo_id in ({str(repos)[1:-1]})
                     """
 
-    # create database connection, load config, execute query above.
-    dbm = AugurManager()
-    dbm.load_pconfig(dbmc)
+    try:
+        dbm = AugurManager()
+        engine = dbm.get_engine()
+    except KeyError:
+        # noack, data wasn't successfully set.
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - INCOMPLETE ENVIRONMENT")
+        return False
+    except SQLAlchemyError:
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - COULDN'T CONNECT TO DB")
+        # allow retry via Celery rules.
+        raise SQLAlchemyError("DBConnect failed")
+
     df = dbm.run_query(query_string)
 
     # change to compatible type and remove all data that has been incorrectly formated

--- a/queries/query_template.py
+++ b/queries/query_template.py
@@ -5,6 +5,7 @@ from app import celery_app
 from cache_manager.cache_manager import CacheManager as cm
 import io
 import datetime as dt
+from sqlalchemy.exc import SQLAlchemyError
 
 """
 TODO:
@@ -28,15 +29,13 @@ QUERY_NAME = "NAME"
     retry_kwargs={"max_retries": 5},
     retry_jitter=True,
 )
-def NAME_query(self, dbmc, repos):
+def NAME_query(self, repos):
     """
     (Worker Query)
     Executes SQL query against Augur database for contributor data.
 
     Args:
     -----
-        dbmc (AugurManager): Handles connection to Augur database, executes queries and returns results.
-
         repo_ids ([str]): repos that SQL query is executed on.
 
     Returns:
@@ -57,9 +56,18 @@ def NAME_query(self, dbmc, repos):
                         repo_id in ({str(repos)[1:-1]})
                 """
 
-    # create database connection, load config, execute query above.
-    dbm = AugurManager()
-    dbm.load_pconfig(dbmc)
+    try:
+        dbm = AugurManager()
+        engine = dbm.get_engine()
+    except KeyError:
+        # noack, data wasn't successfully set.
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - INCOMPLETE ENVIRONMENT")
+        return False
+    except SQLAlchemyError:
+        logging.error(f"{QUERY_NAME}_DATA_QUERY - COULDN'T CONNECT TO DB")
+        # allow retry via Celery rules.
+        raise SQLAlchemyError("DBConnect failed")
+
     df = dbm.run_query(query_string)
 
     # pandas column and format updates


### PR DESCRIPTION
fixes #253
previously, pconfig was an object passed to celery workers that contained database access credentials in lieu of sending a global-scope instantiated AugurManager object.

this is replaced by created a new AugurManager object in each Celery worker process new from the available environment variables.

This should be more secure because we're not passing access parameters, in plaintext, between processes, as worker parameters.