### PR TITLE
name change from drive by to drive thru

### DIFF
--- a/pages/chaoss/visualizations/contrib_drive_repeat.py
+++ b/pages/chaoss/visualizations/contrib_drive_repeat.py
@@ -87,7 +87,7 @@ gc_contrib_drive_repeat = dbc.Card(
                                                 "value": "repeat",
                                             },
                                             {
-                                                "label": "Drive-By",
+                                                "label": "Drive-Thru",
                                                 "value": "drive",
                                             },
                                         ],
@@ -137,7 +137,7 @@ def toggle_popover_1(n, is_open):
 def graph_title(view):
     title = ""
     if view == "drive":
-        title = "Drive-by Contributions Per Quarter"
+        title = "Drive-Thru Contributions Per Quarter"
     else:
         title = "Repeat Contributions Per Quarter"
     return title


### PR DESCRIPTION
"drive by" has a bit of a negative/loaded connotation. Drive-thru gives the same meaning without the connotation  