### PR TITLE
clean up docker files, use dns, add load balancer

### DIFF
--- a/cache_manager/cache_manager.py
+++ b/cache_manager/cache_manager.py
@@ -45,8 +45,8 @@ class CacheManager:
     def __init__(self, decode_value=False):
         # Redis cache for job queue and results cache
         self._redis = StrictRedis(
-            # openshift will reconcile the 'redis' naming via the dns
-            host=os.getenv("REDIS_SERVICE_HOST", "localhost"),
+            # openshift, compose will reconcile the 'redis' naming via the dns
+            host=os.getenv("REDIS_SERVICE_HOST", "redis-cache"),
             port=os.getenv("REDIS_SERVICE_PORT", "6379"),
             password=os.getenv("REDIS_PASSWORD", ""),
             decode_responses=decode_value,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,43 @@
 services:
-  web-server:
+
+  reverse-proxy:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - app-server
+    ports:
+      - "8050:8051" # bound to host port, exposed app endpoint
+    networks:
+      - app-net
+
+  app-server:
     build:
       context: .
       dockerfile: ./docker/Dockerfile.server
     ports:
-      - 8050:8050
+      - 8050
     depends_on:
       - callback-worker
       - query-worker
-      - cache
+      - redis-cache
     env_file:
       - ./env.list
-    environment:
-      REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6379
     restart: always
+    networks:
+      - app-net
 
   callback-worker:
     build:
       context: .
       dockerfile: ./docker/Dockerfile.worker
     depends_on:
-      - cache
+      - redis-cache
     env_file:
       - ./env.list
-    environment:
-      REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6379
     restart: always
+    networks:
+      - app-net
 
   query-worker:
     build:
@@ -44,19 +54,20 @@ services:
         "data"
       ]
     depends_on:
-      - cache
+      - redis-cache
     env_file:
       - ./env.list
-    environment:
-      REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6379
     restart: always
+    networks:
+      - app-net
 
-  cache:
+  redis-cache:
     image: redis
     ports:
-      - 6379:6379
+      - 6379
     restart: always
+    networks:
+      - app-net
 
   flower:
     build:
@@ -65,12 +76,17 @@ services:
     depends_on:
       - callback-worker
       - query-worker
-      - cache
-      - web-server
+      - redis-cache
+      - app-server
     env_file:
       - ./env.list
-    environment:
-      REDIS_SERVICE_HOST: cache
-      REDIS_SERVICE_PORT: 6379
     ports:
       - 5555:5555
+    networks:
+      - app-net
+    profiles:
+      - monitoring # run w/ '--profile monitoring' flag to enable
+
+networks:
+  app-net:
+    driver: bridge

--- a/docker/Dockerfile.flower
+++ b/docker/Dockerfile.flower
@@ -1,33 +1,14 @@
 FROM registry.access.redhat.com/ubi9/python-39
 
-# need this for the Dash app
-EXPOSE 8050
+WORKDIR /8knot
 
-# install pipenv
-RUN pip --no-cache-dir install pipenv
-RUN pip --no-cache-dir install flower
-
-# create a working directory
-# RUN mkdir explorer
-
-# set that directory as working dir
-WORKDIR /explorer
-
-# environment first
-# COPY ./Pipfile.lock /explorer/
-# COPY ./Pipfile /explorer/
-
-# install required modules at system level
-# RUN pipenv install --system --deploy
-
-COPY ./requirements.txt /explorer/
+# install required packages
+COPY ./requirements.txt /8knot/
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 # copy the contents of current file into the
 # working directory.
-COPY ./ /explorer/
+COPY ./ /8knot/
 
 # run worker
-# CMD [ "rq", "worker", "-c", "worker_settings" ]
-# CMD ["celery", "-A", "app:celery_app", "--broker", "redis://:@cache:6379", "flower"]
 CMD ["celery", "-A", "app:celery_app", "flower"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,30 +1,14 @@
 FROM registry.access.redhat.com/ubi9/python-39
 
-# need this for the Dash app
-EXPOSE 8050
+WORKDIR /8knot
 
-# install pipenv
-# RUN pip --no-cache-dir install pipenv
-
-# create a working directory
-# RUN mkdir explorer
-
-# set that directory as working dir
-WORKDIR /explorer
-
-# environment first
-# COPY ./Pipfile.lock /explorer/
-# COPY ./Pipfile /explorer/
-
-# install required modules at system level
-# RUN pipenv install --system --deploy
-
-COPY ./requirements.txt /explorer/
+# install requirements
+COPY ./requirements.txt /8knot/
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 # copy the contents of current file into the
 # working directory.
-COPY ./ /explorer/
+COPY ./ /8knot/
 
 # run app
 # Description of how to choose the number of workers and threads.

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,31 +1,14 @@
 FROM registry.access.redhat.com/ubi9/python-39
 
-# need this for the Dash app
-EXPOSE 8050
+WORKDIR /8knot
 
-# install pipenv
-RUN pip --no-cache-dir install pipenv
-
-# create a working directory
-# RUN mkdir explorer
-
-# set that directory as working dir
-WORKDIR /explorer
-
-# environment first
-# COPY ./Pipfile.lock /explorer/
-# COPY ./Pipfile /explorer/
-
-# install required modules at system level
-# RUN pipenv install --system --deploy
-
-COPY ./requirements.txt /explorer/
+# install required packages
+COPY ./requirements.txt /8knot/
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 # copy the contents of current file into the
 # working directory.
-COPY ./ /explorer/
+COPY ./ /8knot/
 
 # run worker
-# CMD [ "rq", "worker", "-c", "worker_settings" ]
 CMD ["celery", "-A", "app:celery_app", "worker", "--loglevel=WARNING"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,13 @@
+user  nginx;
+events {
+    worker_connections   1000;
+}
+http {
+        server {
+              listen 8051;
+	      access_log  /dev/null; # disables logging on every request
+              location / {
+                proxy_pass http://app-server:8050;
+              }
+        }
+}

--- a/worker_settings.py
+++ b/worker_settings.py
@@ -1,6 +1,6 @@
 import os
 
-redis_host = "{}".format(os.getenv("REDIS_SERVICE_HOST", "localhost"))
+redis_host = "{}".format(os.getenv("REDIS_SERVICE_HOST", "redis-cache"))
 redis_port = "{}".format(os.getenv("REDIS_SERVICE_PORT", "6379"))
 redis_password = "{}@".format(os.getenv("REDIS_PASSWORD", ""))
 


### PR DESCRIPTION
Refactors docker-compose file to only expose
the nginx load balancer and the optional flower
monitoring utility. All other services remain unexposed and are assigned ports by the OS to avoid semantic service collisions (Redis running on 6379 won't collide).

Also cleans up Dockerfiles and enforces DNS-only service referencing, rather than IP-based.