### PR TITLE
adds oauth public config to openshift definitions

### DIFF
--- a/openshift/base/secret-augur.yaml
+++ b/openshift/base/secret-augur.yaml
@@ -12,5 +12,10 @@ stringData:
   AUGUR_PORT: '5432'
   AUGUR_SCHEMA: augur_data
   AUGUR_USERNAME: eightknot
+  AUGUR_LOGIN_ENABLED: true
+  OAUTH_CLIENT_NAME: augur
+  OAUTH_AUTHORIZE_URL: 'https://eightknot.chaoss.tv/user/authorize'
+  OAUTH_TOKEN_URL: 'https://eightknot.chaoss.tv/api/unstable/user/session/generate'
+  OAUTH_REDIRECT_URL: 'https://dev.eightknot.osci.io/authorize'
   # fix: invalid env var
   # 8KNOT_DEBUG: 'True'


### PR DESCRIPTION
8Knot app needs these definition in order to connect to the Augur frontend authorization client for login flow.