### PR TITLE
adds redis instance for user session data to OCP

### DIFF
--- a/8Knot/_login.py
+++ b/8Knot/_login.py
@@ -67,7 +67,7 @@ def configure_server_login(server):
             User | None: User object if user ID in session, None otherwise.
         """
         users_cache = redis.StrictRedis(
-            host="redis-users",
+            host=os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users"),
             port=6379,
             password=os.getenv("REDIS_PASSWORD", ""),
         )
@@ -97,7 +97,7 @@ def configure_server_login(server):
 
         """
         users_cache = redis.StrictRedis(
-            host="redis-users",
+            host=os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users"),
             port=6379,
             password=os.getenv("REDIS_PASSWORD", ""),
         )
@@ -128,7 +128,7 @@ def configure_server_login(server):
             None
         """
         users_cache = redis.StrictRedis(
-            host="redis-users",
+            host=os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users"),
             port=6379,
             password=os.getenv("REDIS_PASSWORD", ""),
         )
@@ -175,7 +175,7 @@ def configure_server_login(server):
             None
         """
         users_cache = redis.StrictRedis(
-            host="redis-users",
+            host=os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users"),
             port=6379,
             password=os.getenv("REDIS_PASSWORD", ""),
         )

--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -52,7 +52,7 @@ def kick_off_group_collection(url, n_clicks):
     if current_user.is_authenticated:
         user_id = current_user.get_id()
         users_cache = redis.StrictRedis(
-            host="redis-users",
+            host=os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users"),
             port=6379,
             password=os.getenv("REDIS_PASSWORD", ""),
         )
@@ -122,7 +122,7 @@ def login_username_button(url):
             logging.warning(f"LOGINBUTTON: USER LOGGED IN {current_user}")
             # TODO: implement more permanent interface
             users_cache = redis.StrictRedis(
-                host="redis-users",
+                host=os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users"),
                 port=6379,
                 password=os.getenv("REDIS_PASSWORD", ""),
             )
@@ -182,7 +182,7 @@ def dynamic_multiselect_options(user_in: str, selections):
         logging.warning(f"LOGINBUTTON: USER LOGGED IN {current_user}")
         # TODO: implement more permanent interface
         users_cache = redis.StrictRedis(
-            host="redis-users",
+            host=os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users"),
             port=6379,
             password=os.getenv("REDIS_PASSWORD", ""),
             decode_responses=True,
@@ -251,7 +251,7 @@ def multiselect_values_to_repo_ids(n_clicks, user_vals):
         logging.warning(f"LOGINBUTTON: USER LOGGED IN {current_user}")
         # TODO: implement more permanent interface
         users_cache = redis.StrictRedis(
-            host="redis-users",
+            host=os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users"),
             port=6379,
             password=os.getenv("REDIS_PASSWORD", ""),
             decode_responses=True,

--- a/8Knot/queries/user_groups_query.py
+++ b/8Knot/queries/user_groups_query.py
@@ -32,7 +32,11 @@ def user_groups_query(self, user_id):
     """
     logging.warning(f"{QUERY_NAME}_DATA_QUERY - START")
 
-    users_cache = redis.StrictRedis(host="redis-users", port=6379, password=os.getenv("REDIS_PASSWORD", ""))
+    users_cache = redis.StrictRedis(
+        host=os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users"),
+        port=6379,
+        password=os.getenv("REDIS_PASSWORD", ""),
+    )
 
     # checks connection to Redis, raises redis.exceptions.ConnectionError if connection fails.
     # returns True if connection succeeds.

--- a/openshift/base/8k-redis-users.yaml
+++ b/openshift/base/8k-redis-users.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"redis:6-el8","namespace":"openshift"},"fieldPath":"spec.template.spec.containers[?(@.name==\"redis-users\")].image","pause":"false"}]'
+  labels:
+    name: eightknot-redis-users
+    app.kubernetes.io/name: eightknot-redis-users
+  name: eightknot-redis-users
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: eightknot-redis-users
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: eightknot-redis-users
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: eightknot-redis
+          image: image-registry.openshift-image-registry.svc:5000/openshift/redis:6-el8
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 6379
+            timeoutSeconds: 1
+          name: eightknot-redis-users
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - test "$(redis-cli -h 127.0.0.1 -a $REDIS_PASSWORD ping)" == "PONG"
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 4Gi
+            requests:
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /var/lib/redis/data
+              name: redis-data
+      restartPolicy: Always
+      volumes:
+        - name: empty
+          emptyDir: {}
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: eightknot-redis-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/part-of: eightknot-app
+  name: eightknot-redis-users
+spec:
+  ports:
+    - name: redis
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+  selector:
+    name: eightknot-redis-users
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: eightknot-redis-users-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4Gi
+  volumeMode: Filesystem

--- a/openshift/base/kustomization.yaml
+++ b/openshift/base/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - 8k-redis.yaml
   - 8k-worker-callback.yaml
   - 8k-worker-query.yaml
+  - 8k-redis-users.yaml
   # - namespace.yaml
   - secret-augur.yaml
   - secret-redis.yaml

--- a/openshift/base/secret-redis.yaml
+++ b/openshift/base/secret-redis.yaml
@@ -9,3 +9,4 @@ stringData:
   REDIS_PASSWORD: secretpassword
   # kludge - rename to REDIS_HOST, REDIS_PORT
   REDIS_SERVICE_HOST: eightknot-redis
+  REDIS_SERVICE_USERS_HOST: eightknot-redis-users


### PR DESCRIPTION
'redis-users' service available in docker-compose definition, but explicit creation of another service for this purpose is required in the openshift resource definitions.

This commit includes these definitions and sets the environment variables required so that services can access the new cache instance.