### PR TITLE
set the searchbar default from the environment

### DIFF
--- a/8Knot/db_manager/augur_manager.py
+++ b/8Knot/db_manager/augur_manager.py
@@ -55,6 +55,7 @@ class AugurManager:
     def __init__(self, handles_oauth=False):
         # sqlalchemy engine object
         self.engine = None
+        self.initial_search_option = None
 
         # db connection credentials
         # if any are unavailable, raise error.
@@ -208,8 +209,6 @@ class AugurManager:
         # self.repo_id_to_repo_git = {value: key for (key, value) in self.repo_git_to_repo_id.items()}
         self.repo_id_to_repo_git = pd.Series(df_repo_git_id.repo_git.values, index=df_repo_git_id["repo_id"]).to_dict()
 
-        # making first selection for the search bar
-        self.initial_search_option = self.multiselect_options[0]
         logging.warning(f"MULTISELECT_FINISHED")
 
     def repo_git_to_id(self, git):
@@ -259,11 +258,27 @@ class AugurManager:
         return org in self.org_names
 
     def initial_multiselect_option(self):
-        """Getter method on first multiselect option
+        """Getter method for the initial multiselect option.
+            May be overwritten by the environment.
 
         Returns:
             dict(value, label): first thing the multiselect will represent on startup
         """
+        if self.initial_search_option is None:
+            # default the initial multiselect option to the
+            # first item in the list of options.
+            self.initial_search_option = self.multiselect_options[0]
+
+            if os.getenv("DEFAULT_SEARCHBAR_LABEL"):
+                logging.warning("INITIAL SEARCHBAR OPTION: DEFAULT OVERWRITTEN")
+
+                # search through available options for the specified overwriting default.
+                for opt in self.multiselect_options:
+                    if os.getenv("DEFAULT_SEARCHBAR_LABEL") == opt["label"]:
+                        logging.warning(f"INITIAL SEARCHBAR OPTION: NEW DEFAULT: {opt}")
+                        self.initial_search_option = opt
+                        break
+
         return self.initial_search_option
 
     def get_multiselect_options(self):

--- a/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
+++ b/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
@@ -149,7 +149,7 @@ gc_contrib_importance_pie = dbc.Card(
                                             max_date_allowed=dt.date.today(),
                                             initial_visible_month=dt.date(dt.date.today().year, 1, 1),
                                             clearable=True,
-                                        ),     
+                                        ),
                                     ],
                                 ),
                                 dbc.Col(
@@ -166,8 +166,8 @@ gc_contrib_importance_pie = dbc.Card(
                                 ),
                             ],
                             align="center",
-                            justify="between",   
-                        )
+                            justify="between",
+                        ),
                     ]
                 ),
             ]
@@ -246,12 +246,12 @@ def process_data(df: pd.DataFrame, action_type, top_k, patterns, start_date, end
     df["created_at"] = pd.to_datetime(df["created_at"], utc=True)
 
     # order values chronologically by created_at date
-    df = df.sort_values(by='created_at', ascending=True)
+    df = df.sort_values(by="created_at", ascending=True)
 
-    # filter values based on date picker 
-    if start_date is not None: 
-        df = df[df.created_at >= start_date] 
-    if end_date is not None: 
+    # filter values based on date picker
+    if start_date is not None:
+        df = df[df.created_at >= start_date]
+    if end_date is not None:
         df = df[df.created_at <= end_date]
 
     # subset the df such that it only contains rows where the Action column value is the action type
@@ -268,7 +268,7 @@ def process_data(df: pd.DataFrame, action_type, top_k, patterns, start_date, end
 
     # sort rows according to amount of contributions from greatest to least
     df.sort_values(by="cntrb_id", ascending=False, inplace=True)
-    df= df.reset_index()
+    df = df.reset_index()
 
     # rename Action column to action_type
     df = df.rename(columns={"Action": action_type})
@@ -289,6 +289,7 @@ def process_data(df: pd.DataFrame, action_type, top_k, patterns, start_date, end
     df = df.append({"cntrb_id": "Other", action_type: t_sum - df_sum}, ignore_index=True)
 
     return df
+
 
 def create_figure(df: pd.DataFrame, action_type):
     # create plotly express pie chart

--- a/8Knot/pages/contributors/visualizations/contrib_importance_pie.py
+++ b/8Knot/pages/contributors/visualizations/contrib_importance_pie.py
@@ -149,7 +149,7 @@ gc_contrib_importance_pie = dbc.Card(
                                             max_date_allowed=dt.date.today(),
                                             initial_visible_month=dt.date(dt.date.today().year, 1, 1),
                                             clearable=True,
-                                        ),     
+                                        ),
                                     ],
                                 ),
                                 dbc.Col(
@@ -166,8 +166,8 @@ gc_contrib_importance_pie = dbc.Card(
                                 ),
                             ],
                             align="center",
-                            justify="between",   
-                        )
+                            justify="between",
+                        ),
                     ]
                 ),
             ]
@@ -246,12 +246,12 @@ def process_data(df: pd.DataFrame, action_type, top_k, patterns, start_date, end
     df["created_at"] = pd.to_datetime(df["created_at"], utc=True)
 
     # order values chronologically by created_at date
-    df = df.sort_values(by='created_at', ascending=True)
+    df = df.sort_values(by="created_at", ascending=True)
 
-    # filter values based on date picker 
-    if start_date is not None: 
-        df = df[df.created_at >= start_date] 
-    if end_date is not None: 
+    # filter values based on date picker
+    if start_date is not None:
+        df = df[df.created_at >= start_date]
+    if end_date is not None:
         df = df[df.created_at <= end_date]
 
     # subset the df such that it only contains rows where the Action column value is the action type
@@ -268,7 +268,7 @@ def process_data(df: pd.DataFrame, action_type, top_k, patterns, start_date, end
 
     # sort rows according to amount of contributions from greatest to least
     df.sort_values(by="cntrb_id", ascending=False, inplace=True)
-    df= df.reset_index()
+    df = df.reset_index()
 
     # rename Action column to action_type
     df = df.rename(columns={"Action": action_type})
@@ -289,6 +289,7 @@ def process_data(df: pd.DataFrame, action_type, top_k, patterns, start_date, end
     df = df.append({"cntrb_id": "Other", action_type: t_sum - df_sum}, ignore_index=True)
 
     return df
+
 
 def create_figure(df: pd.DataFrame, action_type):
     # create plotly express pie chart


### PR DESCRIPTION
allows deployer to set an environment variable for the label of the repo/org they'd like the searchbar to default to on startup.

If the variable not set, default is the first option available in the options list.