### PR TITLE
TEMP deregisters assignment query and visualizations

### DIFF
--- a/8Knot/pages/contributions/contributions.py
+++ b/8Knot/pages/contributions/contributions.py
@@ -28,14 +28,14 @@ layout = dbc.Container(
             align="center",
             style={"marginBottom": ".5%"},
         ),
-        dbc.Row(
-            [
-                dbc.Col(gc_cntrib_pr_assignment, width=6),
-                dbc.Col(gc_pr_assignment, width=6),
-            ],
-            align="center",
-            style={"marginBottom": ".5%"},
-        ),
+        # dbc.Row(
+        #     [
+        #         dbc.Col(gc_cntrib_pr_assignment, width=6),
+        #         dbc.Col(gc_pr_assignment, width=6),
+        #     ],
+        #     align="center",
+        #     style={"marginBottom": ".5%"},
+        # ), # ASSIGNMENT DEREG
         dbc.Row(
             [
                 dbc.Col(gc_issue_staleness, width=6),
@@ -44,14 +44,14 @@ layout = dbc.Container(
             align="center",
             style={"marginBottom": ".5%"},
         ),
-        dbc.Row(
-            [
-                dbc.Col(gc_cntrib_issue_assignment, width=6),
-                dbc.Col(gc_issue_assignment, width=6),
-            ],
-            align="center",
-            style={"marginBottom": ".5%"},
-        ),
+        # dbc.Row(
+        #     [
+        #         dbc.Col(gc_cntrib_issue_assignment, width=6),
+        #         dbc.Col(gc_issue_assignment, width=6),
+        #     ],
+        #     align="center",
+        #     style={"marginBottom": ".5%"},
+        # ), # ASSIGNMENT DEREG
         dbc.Row(
             [
                 dbc.Col(gc_commits_over_time, width=6),

--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -18,14 +18,17 @@ from queries.contributors_query import contributors_query as cnq
 from queries.prs_query import prs_query as prq
 from queries.company_query import company_query as cmq
 from queries.pr_assignee_query import pr_assignee_query as praq
-from queries.issue_assignee_query import issue_assignee_query as iaq
-from queries.user_groups_query import user_groups_query as ugq
+
+# from queries.issue_assignee_query import issue_assignee_query as iaq # ASSIGNMENT DEREG
+# from queries.user_groups_query import user_groups_query as ugq # ASSIGNMENT DEREG
+
 import redis
 import flask
 
 
 # list of queries to be run
-QUERIES = [iq, cq, cnq, prq, cmq, iaq, praq]
+# QUERIES = [iq, cq, cnq, prq, cmq, iaq, praq] #ASSIGNMENT DREG
+QUERIES = [iq, cq, cnq, prq, cmq]
 
 # check if login has been enabled in config
 login_enabled = os.getenv("AUGUR_LOGIN_ENABLED", "False") == "True"


### PR DESCRIPTION
temporarily deregisters the assignment queries and their respective functionality.

when we push to main again in the future, we'll have to remember to rebase and remove this commit.