### PR TITLE
shortens max job lifespan

### DIFF
--- a/8Knot/_celery.py
+++ b/8Knot/_celery.py
@@ -15,6 +15,7 @@ celery_app = Celery(
     backend=REDIS_URL,
 )
 
-celery_app.conf.update(task_time_limit=84600, task_acks_late=True, task_track_started=True)
+# tasks have 30 minutes to execute before they're killed.
+celery_app.conf.update(task_time_limit=1800, task_acks_late=True, task_track_started=True)
 
 celery_manager = CeleryManager(celery_app=celery_app)


### PR DESCRIPTION
Jobs can live 30 minutes at most - shorter than the previous 24hr time limit. This should be a simple fix for observed bugs when a job gets stuck waiting on something that failed. Shouldn't be a replacement for inter-job communication but is a simple patch to minimize impact.