### PR TITLE
re-registers user-group-query bug

### DIFF
--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -17,10 +17,10 @@ from queries.commits_query import commits_query as cq
 from queries.contributors_query import contributors_query as cnq
 from queries.prs_query import prs_query as prq
 from queries.company_query import company_query as cmq
-from queries.pr_assignee_query import pr_assignee_query as praq
+from queries.user_groups_query import user_groups_query as ugq
 
 # from queries.issue_assignee_query import issue_assignee_query as iaq # ASSIGNMENT DEREG
-# from queries.user_groups_query import user_groups_query as ugq # ASSIGNMENT DEREG
+# from queries.pr_assignee_query import pr_assignee_query as praq # ASSIGNMENT DEREG
 
 import redis
 import flask


### PR DESCRIPTION
switches deregistration: re-registers user_groups_query and de-registers pr_assignment_query.

fixes user groups bug we saw on Openshift.