### PR TITLE
Search bar option fix and loading error

### DIFF
--- a/8Knot/pages/codebase/visualizations/cntrb_file_heatmap.py
+++ b/8Knot/pages/codebase/visualizations/cntrb_file_heatmap.py
@@ -79,7 +79,7 @@ graph_loading = html.Div(
                                     id=f"directory-{PAGE}-{VIZ_ID}",
                                     classNames={"values": "dmc-multiselect-custom"},
                                     searchable=True,
-                                    clearable=True,
+                                    clearable=False,
                                 ),
                             ],
                             className="me-2",
@@ -192,7 +192,9 @@ def directory_dropdown(repo_id):
 
     # take all of the files, split on the last instance of a / to get directories and top level files
     directories = df["file_path"].str.rsplit("/", n=1).str[0].tolist()
-    directories = list(set(directories))
+    # applies another rsplit to make sure directories that only have folders are included
+    folder_only_directories = [x.rsplit("/", 1)[0] for x in directories]
+    directories = list(set(directories + folder_only_directories))
 
     # get all of the file names to filter out of the directory set
     top_level_files = df["file_name"][df[1].isnull()].tolist()

--- a/8Knot/pages/codebase/visualizations/contribution_file_heatmap.py
+++ b/8Knot/pages/codebase/visualizations/contribution_file_heatmap.py
@@ -73,7 +73,7 @@ graph_loading = html.Div(
                                     id=f"directory-{PAGE}-{VIZ_ID}",
                                     classNames={"values": "dmc-multiselect-custom"},
                                     searchable=True,
-                                    clearable=True,
+                                    clearable=False,
                                 ),
                             ],
                             className="me-2",
@@ -210,7 +210,9 @@ def directory_dropdown(repo_id):
 
     # get all of the file names to filter out of the directory set
     top_level_files = df["file_name"][df[1].isnull()].tolist()
-    directories = [f for f in directories if f not in top_level_files]
+    # applies another rsplit to make sure directories that only have folders are included
+    folder_only_directories = [x.rsplit("/", 1)[0] for x in directories]
+    directories = list(set(directories + folder_only_directories))
 
     # sort alphabetically
     directories = sorted(directories)


### PR DESCRIPTION
As pointed out by @GregSutcliffe some directories were not getting listed. I figured out it was the ones that only had nested folders and no other files. Additional step makes sure that those directories are listed. 

Changed drop down to not be clearable to prevent reloads that were causing issues 