### PR TITLE
fix queries to accept null timestamps

### DIFF
--- a/8Knot/cache_manager/db_init.py
+++ b/8Knot/cache_manager/db_init.py
@@ -117,11 +117,12 @@ def _create_application_tables() -> None:
 
     with conn.cursor() as cur:
         # create tables if they don't already exist.
+        # TODO: id->repo_id, commits->commit_id
         cur.execute(
             """
             CREATE UNLOGGED TABLE IF NOT EXISTS commits_query(
-                id integer,
-                commits text PRIMARY KEY,
+                id int,
+                commits text, -- this is the commit hash, so it's base64 hash.
                 author_email text,
                 date text,
                 author_timestamp text,
@@ -133,11 +134,11 @@ def _create_application_tables() -> None:
         cur.execute(
             """
             CREATE UNLOGGED TABLE IF NOT EXISTS issues_query(
-                id integer,
+                id int,
                 repo_name text,
-                issue text,
-                issue_number text,
-                gh_issue text,
+                issue int,
+                issue_number int,
+                gh_issue int,
                 reporter_id text,
                 issue_closer text,
                 created text,
@@ -150,10 +151,10 @@ def _create_application_tables() -> None:
         cur.execute(
             """
             CREATE UNLOGGED TABLE IF NOT EXISTS prs_query(
-                id integer,
+                id int,
                 repo_name text,
-                pull_request text,
-                pr_src_number text,
+                pull_request int,
+                pr_src_number int,
                 cntrb_id text,
                 created text,
                 closed text,
@@ -168,10 +169,10 @@ def _create_application_tables() -> None:
             CREATE UNLOGGED TABLE IF NOT EXISTS company_query(
                 cntrb_id text,
                 created text,
-                id integer,
+                id int,
                 login text,
                 action text,
-                rank integer,
+                rank int,
                 cntrb_company text,
                 email_list text
             )
@@ -182,13 +183,13 @@ def _create_application_tables() -> None:
         cur.execute(
             """
             CREATE UNLOGGED TABLE IF NOT EXISTS contributors_query(
-                id integer,
+                id int,
                 repo_name text,
                 cntrb_id text,
                 created_at text,
                 login text,
                 action text,
-                rank integer
+                rank int
             )
             """
         )
@@ -198,7 +199,7 @@ def _create_application_tables() -> None:
             """
             CREATE UNLOGGED TABLE IF NOT EXISTS issue_assignee_query(
                 issue_id text,
-                id integer,
+                id int,
                 created text,
                 closed text,
                 assign_date text,
@@ -212,8 +213,8 @@ def _create_application_tables() -> None:
         cur.execute(
             """
             CREATE UNLOGGED TABLE IF NOT EXISTS pr_assignee_query(
-                pull_request_id text,
-                id integer,
+                pull_request_id int,
+                id int,
                 created text,
                 closed text,
                 assign_date text,
@@ -228,7 +229,7 @@ def _create_application_tables() -> None:
             """
             CREATE UNLOGGED TABLE IF NOT EXISTS cntrb_per_file_query(
                 file_path text,
-                id integer,
+                id int,
                 cntrb_ids text
             )
             """
@@ -239,8 +240,8 @@ def _create_application_tables() -> None:
             """
             CREATE UNLOGGED TABLE IF NOT EXISTS pr_file_query(
                 file_path text,
-                pull_request integer,
-                id integer
+                pull_request int,
+                id int
             )
             """
         )

--- a/8Knot/queries/commits_query.py
+++ b/8Knot/queries/commits_query.py
@@ -50,6 +50,7 @@ def commits_query(self, repos):
                         c.repo_id in %s
                         and timezone('utc', c.cmt_author_timestamp) < now()
                         and timezone('utc', c.cmt_committer_timestamp) < now()
+                        -- Above queries are always non-null so we don't have to check them.
                     """
 
     # used for caching

--- a/8Knot/queries/company_query.py
+++ b/8Knot/queries/company_query.py
@@ -52,6 +52,7 @@ def company_query(self, repos):
                     WHERE
                         c.repo_id in %s
                         and timezone('utc', c.created_at) < now() -- created_at is a timestamptz value
+                        -- don't need to check non-null for created_at because it's non-null by definition.
                     GROUP BY c.cntrb_id, c.created_at, c.repo_id, c.login, c.action, c.rank, con.cntrb_company
                     ORDER BY
                         c.created_at

--- a/8Knot/queries/contributors_query.py
+++ b/8Knot/queries/contributors_query.py
@@ -51,6 +51,7 @@ def contributors_query(self, repos):
                     WHERE
                         ca.repo_id in %s
                         and timezone('utc', ca.created_at) < now() -- created_at is a timestamptz value
+                        -- don't need to check non-null for created_at because it's non-null by definition.
                 """
 
     # used for caching

--- a/8Knot/queries/issue_assignee_query.py
+++ b/8Knot/queries/issue_assignee_query.py
@@ -46,8 +46,10 @@ def issue_assignee_query(self, repos):
                     WHERE
                         ia.id in %s
                         and ia.created < now()
-                        and ia.closed < now()
-                        and ia.assign_date < now()
+                        and (ia.closed < now() or ia.closed IS NULL)
+                        and (ia.assign_date < now() or ia.assign_date IS NULL)
+                        -- have to accept NULL values because issues could still be open, or unassigned,
+                        -- and still be acceptable.
                 """
 
     # used for caching

--- a/8Knot/queries/issues_query.py
+++ b/8Knot/queries/issues_query.py
@@ -49,7 +49,9 @@ def issues_query(self, repos):
                         r.repo_id in %s
                         and i.pull_request_id is null
                         and i.created_at < now()
-                        and i.closed_at < now()
+                        and (i.closed_at < now() or i.closed_at IS NULL)
+                        -- have to accept NULL values because issues could still be open, or unassigned,
+                        -- and still be acceptable.
                     ORDER BY i.created_at
                     """
 

--- a/8Knot/queries/pr_assignee_query.py
+++ b/8Knot/queries/pr_assignee_query.py
@@ -46,8 +46,10 @@ def pr_assignee_query(self, repos):
                     WHERE
                         pa.id in %s
                         and pa.created < now()
-                        and pa.closed < now()
-                        and pa.assign_date < now()
+                        and (pa.closed < now() or pa.closed IS NULL)
+                        and (pa.assign_date < now() or pa.assign_date IS NULL)
+                        -- have to accept NULL values because PRs could still be open, or unassigned,
+                        -- and still be acceptable.
                 """
 
     # used for caching

--- a/8Knot/queries/prs_query.py
+++ b/8Knot/queries/prs_query.py
@@ -28,7 +28,7 @@ def prs_query(self, repos):
     if len(repos) == 0:
         return None
 
-    query_string = f"""
+    query_string = """
                     SELECT
                         r.repo_id,
                         r.repo_name,
@@ -46,10 +46,13 @@ def prs_query(self, repos):
                         r.repo_id = pr.repo_id AND
                         r.repo_id in %s
                         and pr.pr_created_at < now()
-                        and pr.pr_closed_at < now()
-                        and pr.pr_merged_at < now()
+                        and (pr.pr_closed_at < now() or pr.pr_closed_at IS NULL)
+                        and (pr.pr_merged_at < now() or pr.pr_merged_at IS NULL)
+                        -- have to accept NULL values because PRs could still be open, or unassigned,
+                        -- and still be acceptable.
                     ORDER BY pr.pr_created_at
                     """
+
     # used for caching
     func_name = prs_query.__name__
 


### PR DESCRIPTION
queries check to make sure event timestamps didn't happen in the future.
this patch adds a check to accept a rows with NULL in timestamp
fields so that if an event hasn't completed (issue or PR closed)
the row is still accepted.
    