### PR TITLE
points redis-users deployment to correct PVC

### DIFF
--- a/openshift/base/8k-redis-users.yaml
+++ b/openshift/base/8k-redis-users.yaml
@@ -64,7 +64,7 @@ spec:
           emptyDir: {}
         - name: redis-data
           persistentVolumeClaim:
-            claimName: eightknot-redis-data
+            claimName: eightknot-redis-users-data
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
regular redis cache and redis-users cache were using the same persistent volume claim. this points the redis-users instance to its own PVC