### PR TITLE
🚚 Update URIs to current GitHub repository

### DIFF
--- a/8Knot/pages/index/index_layout.py
+++ b/8Knot/pages/index/index_layout.py
@@ -146,7 +146,7 @@ navbar_bottom = dbc.NavbarSimple(
         dbc.NavItem(
             dbc.NavLink(
                 "Visualization request",
-                href="https://github.com/sandiego-rh/explorer/issues/new?assignees=&labels=enhancement%2Cvisualization&template=visualizations.md",
+                href="https://github.com/oss-aspen/8Knot/issues/new?assignees=&labels=enhancement%2Cvisualization&template=visualizations.md",
                 external_link="True",
                 target="_blank",
             )
@@ -154,7 +154,7 @@ navbar_bottom = dbc.NavbarSimple(
         dbc.NavItem(
             dbc.NavLink(
                 "Bug",
-                href="https://github.com/sandiego-rh/explorer/issues/new?assignees=&labels=bug&template=bug_report.md",
+                href="https://github.com/oss-aspen/8Knot/issues/new?assignees=&labels=bug&template=bug_report.md",
                 external_link="True",
                 target="_blank",
             )
@@ -162,7 +162,7 @@ navbar_bottom = dbc.NavbarSimple(
         dbc.NavItem(
             dbc.NavLink(
                 "Repo/Org Request",
-                href="https://github.com/sandiego-rh/explorer/issues/new?assignees=&labels=augur&template=augur_load.md",
+                href="https://github.com/oss-aspen/8Knot/issues/new?assignees=&labels=augur&template=augur_load.md",
                 external_link="True",
                 target="_blank",
             )

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ from a local instance, be scrutinized heavily until we make a proper, stable, >1
 
 ## Communication
 
-Please feel free to join our [Matrix](https://matrix.to/#/#sandiego-rh:matrix.org) channel!
+Please feel free to join our [Matrix](https://matrix.to/#/#oss-aspen:matrix.org) channel!
 
 We would prefer any initial communication be through Matrix but if you would prefer to talk to one of our maintainers, please feel free to peruse our [AUTHORS.md](docs/AUTHORS.md) file where you can find contact details.
 

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -27,7 +27,7 @@ IF you need to add a new query:
 
 ## Steps to create a new page
 
-1. Add a folder to the [pages](https://github.com/sandiego-rh/explorer/tree/dev/pages) folder with a visualization folder inside and a .py for the respective page
+1. Add a folder to the [pages](https://github.com/oss-aspen/8Knot/tree/dev/pages) folder with a visualization folder inside and a .py for the respective page
 2. Use the other pages for format, making sure to include dash.register_page(__name__, order=)
 
 ## Where can I go for help?


### PR DESCRIPTION
While seeking out how to report a bug in the project, I realized that the old repository/project name was still used in several places. This commit updates all remaining references from `sandiego-rh` to `oss-aspen`, matching the new name and pointing users the right way.