### PR TITLE
Codebase page: swap first 2 heatmaps

### DIFF
--- a/8Knot/pages/codebase/codebase.py
+++ b/8Knot/pages/codebase/codebase.py
@@ -16,14 +16,14 @@ layout = dbc.Container(
     [
         dbc.Row(
             [
-                dbc.Col(gc_cntrb_file_heatmap, width=12),
+                dbc.Col(gc_contribution_file_heatmap, width=12),
             ],
             align="center",
             style={"marginBottom": ".5%"},
         ),
         dbc.Row(
             [
-                dbc.Col(gc_contribution_file_heatmap, width=12),
+                dbc.Col(gc_cntrb_file_heatmap, width=12),
             ],
             align="center",
             style={"marginBottom": ".5%"},


### PR DESCRIPTION
I have been thinking about this for a while. Swapping order to put the most conceptually accessible graph first and the contributor/reviewer one next to each other