### PR TITLE
fixes postgres cache pv path

### DIFF
--- a/openshift/base/8k-postgres-cache.yaml
+++ b/openshift/base/8k-postgres-cache.yaml
@@ -26,7 +26,7 @@ spec:
           ports:
             - containerPort: 5432
           volumeMounts:
-            - mountPath: /var/lib/postgresql/data
+            - mountPath: /var/lib/pgql/data
               name: postgres-cache-data
           envFrom:
             - secretRef:


### PR DESCRIPTION
postgres container was pointing to the wrong path to access the PV we set up for it.
data was being written to the container ephemeral storage rather than the pv, leading
to schema issues if the cache pod is restarted without having been initialized correctly
by the 8knot application server init pot
Signed-off-by: James Kunstle <jkunstle@redhat.com>
