### PR TITLE
Add Collection date to OSSF scorecard

### DIFF
--- a/8Knot/cache_manager/db_init.py
+++ b/8Knot/cache_manager/db_init.py
@@ -306,7 +306,8 @@ def _create_application_tables() -> None:
             CREATE UNLOGGED TABLE IF NOT EXISTS ossf_score_query(
                 repo_id int,
                 name text,
-                score float4
+                score float4,
+                data_collection_date timestamp
             )
             """
         )
@@ -323,7 +324,8 @@ def _create_application_tables() -> None:
                 stars_count int,
                 code_of_conduct_file text,
                 security_issue_file text,
-                security_audit_file text
+                security_audit_file text,
+                data_collection_date timestamp
             )
             """
         )

--- a/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
+++ b/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
@@ -85,10 +85,7 @@ def toggle_popover(n, is_open):
 
 # callback for ossf scorecard
 @callback(
-    [
-        Output(f"{PAGE}-{VIZ_ID}", "children"),
-        Output(f"{PAGE}-{VIZ_ID}-updated", "children")
-    ],
+    [Output(f"{PAGE}-{VIZ_ID}", "children"), Output(f"{PAGE}-{VIZ_ID}-updated", "children")],
     [
         Input("repo-info-selection", "value"),
     ],
@@ -137,13 +134,12 @@ def ossf_scorecard(repo):
         for t in unique_updated_times:
             logging.warning(f"t: {t}, {type(t)}")
 
-        
         if len(unique_updated_times) > 1:
             logging.warning(f"{VIZ_ID} - MORE THAN ONE DATA COLLECTION DATE")
-        
+
         logging.warning(f"unique_updated_times: {unique_updated_times}")
 
-        updated_date =  pd.to_datetime(str(unique_updated_times[-1])).strftime("%d/%m/%Y")
+        updated_date = pd.to_datetime(str(unique_updated_times[-1])).strftime("%d/%m/%Y")
         logging.warning(f"updated_date: {updated_date}")
     except Exception as e:
         logging.error(f"Error converting date: {e}")

--- a/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
+++ b/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
@@ -118,7 +118,7 @@ def ossf_scorecard(repo):
     df.drop(["repo_id"], axis=1, inplace=True)
 
     # get all values from the data_collection_date column
-    updated_times = df[["data_collection_date"]]
+    updated_times = pd.to_datetime(df["data_collection_date"])
 
     # we dont need to display this column for every entry
     df.drop(["data_collection_date"], axis=1, inplace=True)
@@ -143,7 +143,6 @@ def ossf_scorecard(repo):
         
         logging.warning(f"unique_updated_times: {unique_updated_times}")
 
-        updated_date = [datetime.fromisoformat(str(ut)) for ut in unique_updated_times]
         logging.warning(f"updated_date: {updated_date}")
         updated_date = updated_date[-1].strftime("%d/%m/%Y")
         logging.warning(f"updated_date: {updated_date}")

--- a/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
+++ b/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
@@ -120,12 +120,6 @@ def ossf_scorecard(repo):
     # get all values from the data_collection_date column
     updated_times = df[["data_collection_date"]]
 
-    unique_updated_times = updated_times.drop_duplicates()
-
-    if len(unique_updated_times) > 1:
-        logging.warning(f"{VIZ_ID} - MORE THAN ONE DATA COLLECTION DATE")
-    
-    
     # we dont need to display this column for every entry
     df.drop(["data_collection_date"], axis=1, inplace=True)
 
@@ -136,10 +130,27 @@ def ossf_scorecard(repo):
     table = dbc.Table.from_dataframe(df, striped=True, bordered=True, hover=True)
 
     # format the date
-    updated_date = [datetime.fromisoformat(ut) for ut in unique_updated_times]
-    logging.info(f"updated_date: {updated_date}")
-    updated_date = updated_date[-1].strftime("%d/%m/%Y")
-    logging.info(f"updated_date: {updated_date}")
+    try:
+        unique_updated_times = updated_times.drop_duplicates()
+        unique_updated_times = unique_updated_times.to_numpy().flatten()
+        logging.warning(unique_updated_times)
+        for t in unique_updated_times:
+            logging.warning(f"t: {t}, {type(t)}")
+
+        
+        if len(unique_updated_times) > 1:
+            logging.warning(f"{VIZ_ID} - MORE THAN ONE DATA COLLECTION DATE")
+        
+        logging.warning(f"unique_updated_times: {unique_updated_times}")
+
+        updated_date = [datetime.fromisoformat(str(ut)) for ut in unique_updated_times]
+        logging.warning(f"updated_date: {updated_date}")
+        updated_date = updated_date[-1].strftime("%d/%m/%Y")
+        logging.warning(f"updated_date: {updated_date}")
+    except Exception as e:
+        logging.error(f"Error converting date: {e}")
+        updated_date = "Error"
+        raise e
 
     logging.warning(f"{VIZ_ID} - END - {time.perf_counter() - start}")
     return table, dbc.Label(updated_date)

--- a/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
+++ b/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
@@ -10,6 +10,7 @@ import io
 import cache_manager.cache_facade as cf
 from pages.utils.job_utils import nodata_graph
 import time
+from datetime import datetime
 
 PAGE = "repo_info"
 VIZ_ID = "ossf-scorecard"
@@ -40,6 +41,14 @@ gc_ossf_scorecard = dbc.Card(
                     [
                         dbc.Row(
                             [
+                                dbc.Col(
+                                    dbc.Row(
+                                        [
+                                            dbc.Label("Last Updated:", className="mr-2"),
+                                            html.Div(id=f"{PAGE}-{VIZ_ID}-updated"),
+                                        ]
+                                    ),
+                                ),
                                 dbc.Col(
                                     dbc.Button(
                                         "Scorecard Info",
@@ -76,7 +85,10 @@ def toggle_popover(n, is_open):
 
 # callback for ossf scorecard
 @callback(
-    Output(f"{PAGE}-{VIZ_ID}", "children"),
+    [
+        Output(f"{PAGE}-{VIZ_ID}", "children"),
+        Output(f"{PAGE}-{VIZ_ID}-updated", "children")
+    ],
     [
         Input("repo-info-selection", "value"),
     ],
@@ -100,10 +112,22 @@ def ossf_scorecard(repo):
     # test if there is data
     if df.empty:
         logging.warning(f"{VIZ_ID} - NO DATA AVAILABLE")
-        return dbc.Table.from_dataframe(df, striped=True, bordered=True, hover=True)
+        return dbc.Table.from_dataframe(df, striped=True, bordered=True, hover=True), dbc.Label("No data")
 
     # repo id not needed for table
     df.drop(["repo_id"], axis=1, inplace=True)
+
+    # get all values from the data_collection_date column
+    updated_times = df[["data_collection_date"]]
+
+    unique_updated_times = updated_times.drop_duplicates()
+
+    if len(unique_updated_times) > 1:
+        logging.warning(f"{VIZ_ID} - MORE THAN ONE DATA COLLECTION DATE")
+    
+    
+    # we dont need to display this column for every entry
+    df.drop(["data_collection_date"], axis=1, inplace=True)
 
     df.loc[df.name == "OSSF_SCORECARD_AGGREGATE_SCORE", "name"] = "Aggregate Score"
     df.sort_values("name", ascending=True, inplace=True)
@@ -111,5 +135,11 @@ def ossf_scorecard(repo):
 
     table = dbc.Table.from_dataframe(df, striped=True, bordered=True, hover=True)
 
+    # format the date
+    updated_date = [datetime.fromisoformat(ut) for ut in unique_updated_times]
+    logging.info(f"updated_date: {updated_date}")
+    updated_date = updated_date[-1].strftime("%d/%m/%Y")
+    logging.info(f"updated_date: {updated_date}")
+
     logging.warning(f"{VIZ_ID} - END - {time.perf_counter() - start}")
-    return table
+    return table, dbc.Label(updated_date)

--- a/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
+++ b/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
@@ -143,7 +143,6 @@ def ossf_scorecard(repo):
         
         logging.warning(f"unique_updated_times: {unique_updated_times}")
 
-        logging.warning(f"updated_date: {updated_date}")
         updated_date = updated_date[-1].strftime("%d/%m/%Y")
         logging.warning(f"updated_date: {updated_date}")
     except Exception as e:

--- a/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
+++ b/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
@@ -45,7 +45,7 @@ gc_ossf_scorecard = dbc.Card(
                                     dbc.Row(
                                         [
                                             dbc.Label(
-                                                ["Last Updated:", html.Span(id=f"{PAGE}-{VIZ_ID}-updated")],
+                                                ["Last Updated: ", html.Span(id=f"{PAGE}-{VIZ_ID}-updated")],
                                                 className="mr-2",
                                             )
                                         ]

--- a/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
+++ b/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
@@ -130,25 +130,12 @@ def ossf_scorecard(repo):
 
     table = dbc.Table.from_dataframe(df, striped=True, bordered=True, hover=True)
 
-    # format the date
-    try:
-        unique_updated_times = updated_times.drop_duplicates()
-        unique_updated_times = unique_updated_times.to_numpy().flatten()
-        logging.warning(unique_updated_times)
-        for t in unique_updated_times:
-            logging.warning(f"t: {t}, {type(t)}")
+    unique_updated_times = updated_times.drop_duplicates().to_numpy().flatten()
 
-        if len(unique_updated_times) > 1:
-            logging.warning(f"{VIZ_ID} - MORE THAN ONE DATA COLLECTION DATE")
+    if len(unique_updated_times) > 1:
+        logging.warning(f"{VIZ_ID} - MORE THAN ONE DATA COLLECTION DATE")
 
-        logging.warning(f"unique_updated_times: {unique_updated_times}")
-
-        updated_date = pd.to_datetime(str(unique_updated_times[-1])).strftime("%d/%m/%Y")
-        logging.warning(f"updated_date: {updated_date}")
-    except Exception as e:
-        logging.error(f"Error converting date: {e}")
-        updated_date = "Error"
-        raise e
+    updated_date = pd.to_datetime(str(unique_updated_times[-1])).strftime("%d/%m/%Y")
 
     logging.warning(f"{VIZ_ID} - END - {time.perf_counter() - start}")
     return table, dbc.Label(updated_date)

--- a/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
+++ b/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
@@ -45,10 +45,8 @@ gc_ossf_scorecard = dbc.Card(
                                     dbc.Row(
                                         [
                                             dbc.Label(
-                                                [
-                                                    "Last Updated:",
-                                                    html.Span(id=f"{PAGE}-{VIZ_ID}-updated")
-                                                ], className="mr-2"
+                                                ["Last Updated:", html.Span(id=f"{PAGE}-{VIZ_ID}-updated")],
+                                                className="mr-2",
                                             )
                                         ]
                                     ),

--- a/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
+++ b/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
@@ -44,8 +44,12 @@ gc_ossf_scorecard = dbc.Card(
                                 dbc.Col(
                                     dbc.Row(
                                         [
-                                            dbc.Label("Last Updated:", className="mr-2"),
-                                            html.Div(id=f"{PAGE}-{VIZ_ID}-updated"),
+                                            dbc.Label(
+                                                [
+                                                    "Last Updated:",
+                                                    html.Span(id=f"{PAGE}-{VIZ_ID}-updated")
+                                                ], className="mr-2"
+                                            )
                                         ]
                                     ),
                                 ),

--- a/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
+++ b/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
@@ -143,7 +143,7 @@ def ossf_scorecard(repo):
         
         logging.warning(f"unique_updated_times: {unique_updated_times}")
 
-        updated_date = updated_date[-1].strftime("%d/%m/%Y")
+        updated_date =  pd.to_datetime(str(unique_updated_times[-1])).strftime("%d/%m/%Y")
         logging.warning(f"updated_date: {updated_date}")
     except Exception as e:
         logging.error(f"Error converting date: {e}")

--- a/8Knot/pages/repo_overview/visualizations/repo_general_info.py
+++ b/8Knot/pages/repo_overview/visualizations/repo_general_info.py
@@ -32,7 +32,7 @@ gc_repo_general_info = dbc.Card(
                 dcc.Loading(
                     html.Div(id=f"{PAGE}-{VIZ_ID}"),
                 ),
-                dbc.Row([dbc.Label(["Last Updated:", html.Span(id=f"{PAGE}-{VIZ_ID}-updated")], className="mr-2")]),
+                dbc.Row([dbc.Label(["Last Updated: ", html.Span(id=f"{PAGE}-{VIZ_ID}-updated")], className="mr-2")]),
             ]
         )
     ],

--- a/8Knot/pages/repo_overview/visualizations/repo_general_info.py
+++ b/8Knot/pages/repo_overview/visualizations/repo_general_info.py
@@ -90,27 +90,16 @@ def repo_general_info(repo):
 
 
 def process_data(df_repo_files, df_repo_info, df_releases):
-
-    # get all values from the data_collection_date column
-    # updated_times_repo_files = pd.to_datetime(df_repo_files["data_collection_date"])
+   
     updated_times_repo_info = pd.to_datetime(df_repo_info["data_collection_date"])
-    # updated_times_releases = pd.to_datetime(df_releases["data_collection_date"])
 
-    # format the date
-    try:
-        # updated_times = pd.concat([updated_times_repo_files, updated_times_repo_info, updated_times_releases])
-        updated_times = updated_times_repo_info
-        unique_updated_times = updated_times.drop_duplicates()
-        unique_updated_times = unique_updated_times.to_numpy().flatten()
+    unique_updated_times = updated_times_repo_info.drop_duplicates().to_numpy().flatten()
 
-        if len(unique_updated_times) > 1:
-            logging.warning(f"{VIZ_ID} - MORE THAN ONE LAST UPDATE DATE")
+    if len(unique_updated_times) > 1:
+        logging.warning(f"{VIZ_ID} - MORE THAN ONE LAST UPDATE DATE")
 
-        updated_date = pd.to_datetime(str(unique_updated_times[-1])).strftime("%d/%m/%Y")
-        logging.warning(f"updated_date: {updated_date}")
-    except Exception as e:
-        logging.error(f"Error converting date: {e}")
-        updated_date = "Error"
+    updated_date = pd.to_datetime(str(unique_updated_times[-1])).strftime("%d/%m/%Y")
+
     # convert to datetime objects rather than strings
     df_releases["release_published_at"] = pd.to_datetime(df_releases["release_published_at"], utc=True)
 

--- a/8Knot/pages/repo_overview/visualizations/repo_general_info.py
+++ b/8Knot/pages/repo_overview/visualizations/repo_general_info.py
@@ -104,7 +104,7 @@ def process_data(df_repo_files, df_repo_info, df_releases):
         if len(unique_updated_times) > 1:
             logging.warning(f"{VIZ_ID} - MORE THAN ONE LAST UPDATE DATE")
 
-        updated_date = updated_date[-1].strftime("%d/%m/%Y")
+        updated_date = pd.to_datetime(str(unique_updated_times[-1])).strftime("%d/%m/%Y")
         logging.warning(f"updated_date: {updated_date}")
     except Exception as e:
         logging.error(f"Error converting date: {e}")

--- a/8Knot/pages/repo_overview/visualizations/repo_general_info.py
+++ b/8Knot/pages/repo_overview/visualizations/repo_general_info.py
@@ -82,7 +82,7 @@ def repo_general_info(repo):
     table = dbc.Table.from_dataframe(df, striped=True, bordered=True, hover=True)
 
     logging.warning(f"{VIZ_ID} - END - {time.perf_counter() - start}")
-    return table
+    return table, last_updated
 
 
 def process_data(df_repo_files, df_repo_info, df_releases):

--- a/8Knot/pages/repo_overview/visualizations/repo_general_info.py
+++ b/8Knot/pages/repo_overview/visualizations/repo_general_info.py
@@ -88,13 +88,14 @@ def repo_general_info(repo):
 def process_data(df_repo_files, df_repo_info, df_releases):
 
     # get all values from the data_collection_date column
-    updated_times_repo_files = pd.to_datetime(df_repo_files["data_collection_date"])
+    # updated_times_repo_files = pd.to_datetime(df_repo_files["data_collection_date"])
     updated_times_repo_info = pd.to_datetime(df_repo_info["data_collection_date"])
-    updated_times_releases = pd.to_datetime(df_releases["data_collection_date"])
+    # updated_times_releases = pd.to_datetime(df_releases["data_collection_date"])
 
     # format the date
     try:
-        updated_times = pd.concat([updated_times_repo_files, updated_times_repo_info, updated_times_releases])
+        # updated_times = pd.concat([updated_times_repo_files, updated_times_repo_info, updated_times_releases])
+        updated_times = updated_times_repo_info
         unique_updated_times = updated_times.drop_duplicates()
         unique_updated_times = unique_updated_times.to_numpy().flatten()
 

--- a/8Knot/pages/repo_overview/visualizations/repo_general_info.py
+++ b/8Knot/pages/repo_overview/visualizations/repo_general_info.py
@@ -32,16 +32,7 @@ gc_repo_general_info = dbc.Card(
                 dcc.Loading(
                     html.Div(id=f"{PAGE}-{VIZ_ID}"),
                 ),
-                dbc.Row(
-                    [
-                        dbc.Label(
-                            [
-                                "Last Updated:",
-                                html.Span(id=f"{PAGE}-{VIZ_ID}-updated")
-                            ], className="mr-2"
-                        )
-                    ]
-                ),
+                dbc.Row([dbc.Label(["Last Updated:", html.Span(id=f"{PAGE}-{VIZ_ID}-updated")], className="mr-2")]),
             ]
         )
     ],
@@ -90,7 +81,7 @@ def repo_general_info(repo):
 
 
 def process_data(df_repo_files, df_repo_info, df_releases):
-   
+
     updated_times_repo_info = pd.to_datetime(df_repo_info["data_collection_date"])
 
     unique_updated_times = updated_times_repo_info.drop_duplicates().to_numpy().flatten()

--- a/8Knot/pages/repo_overview/visualizations/repo_general_info.py
+++ b/8Knot/pages/repo_overview/visualizations/repo_general_info.py
@@ -15,6 +15,7 @@ import io
 import cache_manager.cache_facade as cf
 from pages.utils.job_utils import nodata_graph
 import time
+from datetime import datetime
 
 PAGE = "repo_info"
 VIZ_ID = "repo-general-info"
@@ -31,6 +32,12 @@ gc_repo_general_info = dbc.Card(
                 dcc.Loading(
                     html.Div(id=f"{PAGE}-{VIZ_ID}"),
                 ),
+                dbc.Row(
+                    [
+                        dbc.Label("Last Updated:", className="mr-2"),
+                        html.Div(id=f"{PAGE}-{VIZ_ID}-updated"),
+                    ]
+                )
             ]
         )
     ],
@@ -51,7 +58,10 @@ def toggle_popover(n, is_open):
 
 # callback for repo general info
 @callback(
-    Output(f"{PAGE}-{VIZ_ID}", "children"),
+    [
+        Output(f"{PAGE}-{VIZ_ID}", "children"),
+        Output(f"{PAGE}-{VIZ_ID}-updated", "children")
+    ],
     [
         Input("repo-info-selection", "value"),
     ],
@@ -68,9 +78,9 @@ def repo_general_info(repo):
     # test if there is data
     if df_repo_files.empty and df_repo_info.empty and df_releases.empty:
         logging.warning(f"{VIZ_ID} - NO DATA AVAILABLE")
-        return dbc.Table.from_dataframe(pd.DataFrame(), striped=True, bordered=True, hover=True)
+        return dbc.Table.from_dataframe(pd.DataFrame(), striped=True, bordered=True, hover=True), dbc.Label("No data")
 
-    df = process_data(df_repo_files, df_repo_info, df_releases)
+    df, last_updated = process_data(df_repo_files, df_repo_info, df_releases)
 
     table = dbc.Table.from_dataframe(df, striped=True, bordered=True, hover=True)
 
@@ -80,6 +90,27 @@ def repo_general_info(repo):
 
 def process_data(df_repo_files, df_repo_info, df_releases):
 
+     # get all values from the data_collection_date column
+    updated_times_repo_files = pd.to_datetime(df_repo_files["data_collection_date"])
+    updated_times_repo_info = pd.to_datetime(df_repo_info["data_collection_date"])
+    updated_times_releases = pd.to_datetime(df_releases["data_collection_date"])
+
+    # format the date
+    try:
+        updated_times = pd.concat([updated_times_repo_files, updated_times_repo_info, updated_times_releases])
+        unique_updated_times = updated_times.drop_duplicates()
+        unique_updated_times = unique_updated_times.to_numpy().flatten()
+
+        if len(unique_updated_times) > 1:
+            logging.warning(f"{VIZ_ID} - MORE THAN ONE LAST UPDATE DATE")
+
+    
+        logging.warning(f"updated_date: {updated_date}")
+        updated_date = updated_date[-1].strftime("%d/%m/%Y")
+        logging.warning(f"updated_date: {updated_date}")
+    except Exception as e:
+        logging.error(f"Error converting date: {e}")
+        updated_date = "Error"
     # convert to datetime objects rather than strings
     df_releases["release_published_at"] = pd.to_datetime(df_releases["release_published_at"], utc=True)
 
@@ -164,7 +195,7 @@ def process_data(df_repo_files, df_repo_info, df_releases):
         }
     )
 
-    return df
+    return df, dbc.Label(updated_date)
 
 
 def multi_query_helper(repos):

--- a/8Knot/pages/repo_overview/visualizations/repo_general_info.py
+++ b/8Knot/pages/repo_overview/visualizations/repo_general_info.py
@@ -37,7 +37,7 @@ gc_repo_general_info = dbc.Card(
                         dbc.Label("Last Updated:", className="mr-2"),
                         html.Div(id=f"{PAGE}-{VIZ_ID}-updated"),
                     ]
-                )
+                ),
             ]
         )
     ],
@@ -58,10 +58,7 @@ def toggle_popover(n, is_open):
 
 # callback for repo general info
 @callback(
-    [
-        Output(f"{PAGE}-{VIZ_ID}", "children"),
-        Output(f"{PAGE}-{VIZ_ID}-updated", "children")
-    ],
+    [Output(f"{PAGE}-{VIZ_ID}", "children"), Output(f"{PAGE}-{VIZ_ID}-updated", "children")],
     [
         Input("repo-info-selection", "value"),
     ],
@@ -90,7 +87,7 @@ def repo_general_info(repo):
 
 def process_data(df_repo_files, df_repo_info, df_releases):
 
-     # get all values from the data_collection_date column
+    # get all values from the data_collection_date column
     updated_times_repo_files = pd.to_datetime(df_repo_files["data_collection_date"])
     updated_times_repo_info = pd.to_datetime(df_repo_info["data_collection_date"])
     updated_times_releases = pd.to_datetime(df_releases["data_collection_date"])

--- a/8Knot/pages/repo_overview/visualizations/repo_general_info.py
+++ b/8Knot/pages/repo_overview/visualizations/repo_general_info.py
@@ -34,8 +34,12 @@ gc_repo_general_info = dbc.Card(
                 ),
                 dbc.Row(
                     [
-                        dbc.Label("Last Updated:", className="mr-2"),
-                        html.Div(id=f"{PAGE}-{VIZ_ID}-updated"),
+                        dbc.Label(
+                            [
+                                "Last Updated:",
+                                html.Span(id=f"{PAGE}-{VIZ_ID}-updated")
+                            ], className="mr-2"
+                        )
                     ]
                 ),
             ]

--- a/8Knot/pages/repo_overview/visualizations/repo_general_info.py
+++ b/8Knot/pages/repo_overview/visualizations/repo_general_info.py
@@ -104,8 +104,6 @@ def process_data(df_repo_files, df_repo_info, df_releases):
         if len(unique_updated_times) > 1:
             logging.warning(f"{VIZ_ID} - MORE THAN ONE LAST UPDATE DATE")
 
-    
-        logging.warning(f"updated_date: {updated_date}")
         updated_date = updated_date[-1].strftime("%d/%m/%Y")
         logging.warning(f"updated_date: {updated_date}")
     except Exception as e:

--- a/8Knot/queries/ossf_score_query.py
+++ b/8Knot/queries/ossf_score_query.py
@@ -33,7 +33,8 @@ def ossf_score_query(self, repos):
                 SELECT
                     repo_id as id,
                     name,
-                    score
+                    score,
+                    data_collection_date
                 FROM
                     repo_deps_scorecard
                 WHERE

--- a/8Knot/queries/repo_info_query.py
+++ b/8Knot/queries/repo_info_query.py
@@ -39,7 +39,8 @@ def repo_info_query(self, repos):
                     stars_count,
                     code_of_conduct_file,
                     security_issue_file,
-                    security_audit_file
+                    security_audit_file,
+                    data_collection_date
                 FROM
                     repo_info ri
                 WHERE


### PR DESCRIPTION
This is a mostly-there first-pass at tackling #720. It adds the date to the bottom of the box for the OSSF scorecard and repo info tiles.

The ossf scorecard one works, the repo info is having some issues that ill work on (ignore my broken fonts on my machine)

![Screenshot_20241007_112324](https://github.com/user-attachments/assets/c4ef4261-b4ec-4293-b788-1865d052cf2d)

TODO:

- [ ] Add the date format to the information popup on each tile
- [ ] detect the date format to use based on users browser locale settings (maybe)
- [ ] debug and fix the repo info tile date
- [ ] determine how to calculate the date for the repo info tile considering the data is coming from three different dataframes (should it just take the last date in the list? most recent? least recent? display a range of both?)



feedback welcome!


closes #720 