### PR TITLE
Update Unique domains - Hover Value wrong - Resolving Issue #743

### DIFF
--- a/8Knot/pages/affiliation/visualizations/unqiue_domains.py
+++ b/8Knot/pages/affiliation/visualizations/unqiue_domains.py
@@ -211,7 +211,7 @@ def create_figure(df: pd.DataFrame):
     fig.update_traces(
         textposition="inside",
         textinfo="percent+label",
-        hovertemplate="%{label} <br>Contributions: %{value}<br><extra></extra>",
+        hovertemplate="%{label} <br>Contributors: %{value}<br><extra></extra>",
     )
 
     return fig


### PR DESCRIPTION
Resolving issue: "Unique Contributor Email Domains Visualization hover value wrong #743"

Previous hover value was showing "Contributions", hover value was changed and updated to "Contributors".

Signed: Caio Fonseca