### PR TITLE
Switching Python Pkg Manager (from Pip to UV) to increase Docker Building speeds - More efficiency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,10 +2,13 @@ FROM registry.access.redhat.com/ubi9/python-39:latest
 
 WORKDIR /opt/app-root/src
 
-# install required packages
-COPY ./requirements.txt /opt/app-root/src/
+# Install UV package installer
 RUN pip3 install --no-cache-dir -U pip setuptools && \
-    pip3 install --no-cache-dir -r requirements.txt
+    pip3 install --no-cache-dir uv
+
+# install required packages with UV
+COPY ./requirements.txt /opt/app-root/src/
+RUN uv pip install --no-cache-dir -r requirements.txt
 
 # copy the contents of current file into the
 # working directory.


### PR DESCRIPTION
UV as a Python Pkg Manager is growing in popularity due to its high speed in installing dependencies and its efficient commands, making it easier to transition from pip to UV. 
The UV has been added into the Dockerfile, and it install all dependencies accordingly. 
The build has been tested in a local instance, and benchmarks were compared between the UV version and the Pip version. The UV version reaches double the speed, so the build, is on average, done in half the time. 