### PR TITLE
db_Init issue fixed

### DIFF
--- a/8Knot/cache_manager/cx_common.py
+++ b/8Knot/cache_manager/cx_common.py
@@ -3,6 +3,7 @@ Connection Common file - accessing environment variables
 """
 import os
 import logging
+import time
 
 # credentials to access database from environment
 try:

--- a/8Knot/cache_manager/db_init.py
+++ b/8Knot/cache_manager/db_init.py
@@ -62,10 +62,41 @@ Generally, 'int' is good for integers,
 import logging
 import sys
 import psycopg2 as pg
+import time
 
 # doesn't use relative import syntax "import .cx_common" because
 # cx_common is a neighbor of script, thus is available in PYTHON_PATH
 from cx_common import init_cx_string, cache_cx_string
+
+
+def _connect_with_retry(connection_string, max_retries=5, retry_delay=3):
+    """
+    Attempt to connect to the database with retries.
+    Args:
+        connection_string: The connection string to use
+        max_retries: Maximum number of retry attempts
+        retry_delay: Seconds to wait between retries
+    Returns:
+        PostgreSQL connection object or None if failed after retries
+    """
+    retries = 0
+    last_exception = None
+    while retries < max_retries:
+        try:
+            logging.warning(f"Attempting database connection (attempt {retries+1}/{max_retries})...")
+            conn = pg.connect(connection_string)
+            logging.warning("Database connection established successfully!")
+            return conn
+        except Exception as e:
+            last_exception = e
+            retries += 1
+            if retries < max_retries:
+                logging.warning(f"Connection failed: {e}. Retrying in {retry_delay} seconds...")
+                time.sleep(retry_delay)
+            else:
+                logging.critical(f"Failed to connect after {max_retries} attempts: {e}")
+    # If we reached here, all connection attempts failed
+    raise last_exception
 
 
 def _create_application_database() -> None:
@@ -82,7 +113,7 @@ def _create_application_database() -> None:
     # we'll always connect to root-level DB
     # with these creds so they don't need to be
     # parameterized.
-    conn = pg.connect(init_cx_string)
+    conn = _connect_with_retry(init_cx_string)
 
     # required so that we can create a database
     conn.autocommit = True
@@ -113,7 +144,7 @@ def _create_application_tables() -> None:
     # TODO: timestamps being stored as strings- don't need to do that anymore.
 
     # connect to application database
-    conn = pg.connect(cache_cx_string)
+    conn = _connect_with_retry(cache_cx_string)
 
     with conn.cursor() as cur:
         # create tables if they don't already exist.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,15 @@ services:
       dockerfile: ./docker/Dockerfile
     command: ["python3", "./cache_manager/db_init.py"]
     depends_on:
-      - postgres-cache
+      postgres-cache:
+        condition: service_healthy # to ensure that postgres is indeed initialized before this starts
     env_file:
       - ./env.list
     # sometimes, postgres-cache isn't spun up before this starts.
     # so it'll fail. We want this to restart when it fails, because
     # postgres will be ready eventually. we don't want it to restart
     # after it succeeds. give it 1000 attempts I guess.
-    restart: on-failure:1000
+    restart: on-failure:1000 
 
   reverse-proxy:
     image: nginx:latest
@@ -129,6 +130,11 @@ services:
     env_file:
       - ./env.list
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 volumes:
   postgres-cache:


### PR DESCRIPTION
This PR fixes the db_init issue as presented in #765 WORKER Timeouts.

In the docker-compose file, there was already a depends-on condition for the db_init to start only after postgres was ready, however, it was not making sure that postgres was actually initialized before the db was initialized. 
This PR ensures that postgres is correctly initialized and pass a health check before the db is initialized.

It also creates a function connection with retries, where it'll go through the same process of connecting the db, but if it fails, it will try the connection again for a max number of retries. 