### PR TITLE
Investigation and Proposed solution to Redis low memory issue #764

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     # so it'll fail. We want this to restart when it fails, because
     # postgres will be ready eventually. we don't want it to restart
     # after it succeeds. give it 1000 attempts I guess.
-    restart: on-failure:1000 
+    restart: on-failure:1000
 
   reverse-proxy:
     image: nginx:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,11 @@ services:
     env_file:
       - ./env.list
     restart: always
+    # NOTE: This setting is for Linux production environments.
+    # It will cause errors on macOS/Windows Docker Desktop, but is kept
+    # in the configuration for deployment to Linux servers.
+    sysctls:
+      - vm.overcommit_memory=1
 
   # for user session storage
   redis-users:
@@ -116,6 +121,11 @@ services:
     env_file:
       - ./env.list
     restart: always
+    # NOTE: This setting is for Linux production environments.
+    # It will cause errors on macOS/Windows Docker Desktop, but is kept
+    # in the configuration for deployment to Linux servers.
+    sysctls:
+      - vm.overcommit_memory=1
 
   postgres-cache:
     image: docker.io/library/postgres:16


### PR DESCRIPTION
Common Redis warning caused due to memory overcommit settings in Linux. 

- Linux has a feature called "memory overcommit" that affects how processes reserve memory; 
- When Redis saves data to disk or replicates, it needs to fork processes. If memory overcommit is disabled, these forks can fail when memory is tight.

The impact of this are: Redis might fail to save data to disk when memory is low. Replication might break, and these failures can cause data loss in certain situations.

Proposed solution for the Linux system is described on the code modifications in this PR. 
It is critical for production, in order to prevent data loss. For development, it is not, as it's generally a warning that things might go wrong in certain situations. For macOS development, for example, it is informing that the system has a conservative memory overcommit policy, which can mean that under very high memory pressure, the Redis background operations might fail, but for development work, it won't be an issue most times. 