### PR TITLE
Increase Timeouts in APPServer and nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
         "1",
         "--threads",
         "2",
+        "--timeout", "180",
       ]
     # ports:
     #   - 8080:8080
@@ -55,6 +56,11 @@ services:
       - EIGHTKNOT_SEARCHBAR_OPTS_MAX_RESULTS=5500 # Maximum number of results to return (org and repo)
       - EIGHTKNOT_SEARCHBAR_OPTS_MAX_REPOS=5000     # Max number of repos
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   worker-callback:
     build:

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,6 +8,9 @@ http {
 	      access_log  /dev/null; # disables logging on every request
               location / {
                 proxy_pass http://app-server:8080;
+                    proxy_read_timeout 180;
+                    proxy_connect_timeout 180;
+                    proxy_send_timeout 180;
               }
         }
 }


### PR DESCRIPTION
After some experimentation on a very heavily loaded Augur instance, I found the changes to `nginx.conf` and `docker-compose.yml` included in this pull request enabled the docker/podman container to launch successfully. 

Notably, the page may still fail to load the first few times, but once 8Knot has the data cached load times are quite reasonable and almost normal in my testing. 