### PR TITLE
New Search Bar Implementation logic fix

### DIFF
--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -33,7 +33,7 @@ from queries.ossf_score_query import ossf_score_query as osq
 from queries.repo_info_query import repo_info_query as riq
 import redis
 import flask
-
+from .search_utils import fuzzy_search
 
 # list of queries to be run
 # QUERIES = [iq, cq, cnq, prq, aq, iaq, praq, prr, cpfq, rfq, prfq, rlq, pvq, rrq, osq, riq] - codebase page disabled
@@ -244,9 +244,6 @@ def dynamic_multiselect_options(user_in: str, selections, cached_options):
         cache_matches = []
         server_matches = []
 
-        # Import the fuzzy search function
-        from .search_utils import fuzzy_search
-
         # Initialize fallback flag
         use_server_fallback = False
 
@@ -381,16 +378,14 @@ def dynamic_multiselect_options(user_in: str, selections, cached_options):
                         break
 
         # NO LIMITS for now: Return all matches with orgs prioritized
-        # Separate orgs and repos from combined results for proper ordering
-        orgs_in_results = [opt for opt in formatted_opts if isinstance(opt["value"], str)]
-        repos_in_results = [opt for opt in formatted_opts if isinstance(opt["value"], int)]
+        # Use the org/repo separation already done
 
         logging.info(
-            f"Final results breakdown: {len(orgs_in_results)} orgs, {len(repos_in_results)} repos, {len(formatted_opts)} total"
+            f"Final results breakdown: {len(orgs_first)} orgs, {len(repos_after)} repos, {len(formatted_opts)} total"
         )
 
-        # Orgs are prioritized first, then repos
-        result = orgs_in_results + repos_in_results
+        # Always prioritize orgs first, then repos, but don't limit the total count
+        result = orgs_first + repos_after
 
         # Add selected options that aren't already in the results
         selected_values = [opt["value"] for opt in result]

--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -186,7 +186,7 @@ def _login_username_button_disabled(url):
 )
 def dynamic_multiselect_options(user_in: str, selections, cached_options):
     """
-    Enhanced search using fuzzy matching and client-side cache.
+    Enhanced search using fuzzy matching and client-side cache with server fallback.
 
     Args:
         user_in: User's search input
@@ -200,7 +200,7 @@ def dynamic_multiselect_options(user_in: str, selections, cached_options):
         start_time = time.time()
         logging.info(f"Search query: '{user_in}'")
 
-        # Use cached options if available, otherwise fall back to server fetch
+        # Start with cached options if available
         if cached_options:
             logging.info(f"Using client-side cache with {len(cached_options)} options")
             options = cached_options
@@ -244,7 +244,89 @@ def dynamic_multiselect_options(user_in: str, selections, cached_options):
         from .search_utils import fuzzy_search
 
         matched_options = fuzzy_search(search_query, options, threshold=0.2)
-        logging.info(f"Fuzzy search found {len(matched_options)} matches")
+        logging.info(f"Fuzzy search found {len(matched_options)} matches in cache")
+
+        # ENSURE EXACT ORG MATCHES: If searching for an org name, make sure it's included
+        # This handles cases where fuzzy search limits might exclude exact org matches
+        if len(search_query) >= 3:  # Only for meaningful queries
+            exact_org_matches = []
+
+            # Check for org matches in the FULL server dataset, not just cache
+            # because orgs might not be in the limited cache
+            try:
+                server_options = augur.get_multiselect_options().copy()
+                if current_user.is_authenticated:
+                    try:
+                        users_cache = redis.StrictRedis(
+                            host=os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users"),
+                            port=6379,
+                            password=os.getenv("REDIS_PASSWORD", ""),
+                            decode_responses=True,
+                        )
+                        users_cache.ping()
+                        if users_cache.exists(f"{current_user.get_id()}_group_options"):
+                            user_options = json.loads(users_cache.get(f"{current_user.get_id()}_group_options"))
+                            server_options = server_options + user_options
+                    except redis.exceptions.ConnectionError as e:
+                        logging.error(f"ORG CHECK: Could not connect to users-cache. Error: {str(e)}")
+
+                for opt in server_options:
+                    if isinstance(opt.get("value"), str):  # It's an org
+                        org_label = opt["label"].lower()
+                        if (
+                            search_query.lower() == org_label
+                            or search_query.lower() in org_label
+                            or org_label.startswith(search_query.lower())
+                        ):
+                            # Check if this org is already in matched_options
+                            if not any(existing["value"] == opt["value"] for existing in matched_options):
+                                exact_org_matches.append(opt)
+
+            except Exception as e:
+                logging.error(f"ORG CHECK: Failed to fetch server options: {str(e)}")
+
+            # Add exact org matches to the beginning
+            if exact_org_matches:
+                matched_options = exact_org_matches + matched_options
+                logging.info(f"Added {len(exact_org_matches)} exact org matches from server")
+
+        # FALLBACK MECHANISM: If we have very few matches and we were using cache,
+        # search the full server dataset
+        use_server_fallback = False
+        if cached_options and len(matched_options) < 5 and len(search_query) >= 3:
+            logging.info("Few matches found in cache, falling back to server search")
+            try:
+                server_options = augur.get_multiselect_options().copy()
+                if current_user.is_authenticated:
+                    try:
+                        users_cache = redis.StrictRedis(
+                            host=os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users"),
+                            port=6379,
+                            password=os.getenv("REDIS_PASSWORD", ""),
+                            decode_responses=True,
+                        )
+                        users_cache.ping()
+                        if users_cache.exists(f"{current_user.get_id()}_group_options"):
+                            user_options = json.loads(users_cache.get(f"{current_user.get_id()}_group_options"))
+                            server_options = server_options + user_options
+                    except redis.exceptions.ConnectionError as e:
+                        logging.error(f"FALLBACK: Could not connect to users-cache. Error: {str(e)}")
+
+                server_matches = fuzzy_search(search_query, server_options, threshold=0.2)
+                logging.info(f"Server fallback found {len(server_matches)} matches")
+
+                # Combine cache and server results, prioritizing cache matches
+                seen_values = set(opt["value"] for opt in matched_options)
+                for server_match in server_matches:
+                    if server_match["value"] not in seen_values:
+                        matched_options.append(server_match)
+                        seen_values.add(server_match["value"])
+
+                use_server_fallback = True
+                logging.info(f"Combined results: {len(matched_options)} total matches")
+
+            except Exception as e:
+                logging.error(f"Server fallback failed: {str(e)}")
 
         # Filter by prefix type if specified
         if prefix_type == "repo":
@@ -273,15 +355,22 @@ def dynamic_multiselect_options(user_in: str, selections, cached_options):
                 formatted_opt["label"] = f"repo: {opt['label']}"
             formatted_opts.append(formatted_opt)
 
+        # Simple reordering: put organizations first, then repositories
+        orgs_first = [opt for opt in formatted_opts if isinstance(opt["value"], str)]
+        repos_after = [opt for opt in formatted_opts if isinstance(opt["value"], int)]
+        formatted_opts = orgs_first + repos_after
+
         # Always include the previous selections
         # Format selected options with prefixes
         selected_options = []
 
-        # First check if selections are in our cache
-        cached_selection_values = set(opt["value"] for opt in options)
-        missing_selections = [v for v in selections if v not in cached_selection_values]
+        # First check if selections are in our current options (cache + any server fallback)
+        current_selection_values = set(
+            opt["value"] for opt in (cached_options or []) + (matched_options if use_server_fallback else [])
+        )
+        missing_selections = [v for v in selections if v not in current_selection_values]
 
-        # If any selections aren't in cache, fetch them from the server
+        # If any selections aren't in our current options, fetch them from the server
         if missing_selections:
             logging.info(f"Fetching {len(missing_selections)} missing selections from server")
             all_options = augur.get_multiselect_options().copy()
@@ -297,9 +386,10 @@ def dynamic_multiselect_options(user_in: str, selections, cached_options):
                         formatted_v["label"] = f"repo: {formatted_v['label']}"
                     selected_options.append(formatted_v)
         else:
-            # All selections are in cache
+            # All selections are in our current options
+            all_current_options = (cached_options or []) + matched_options
             for v in selections:
-                for opt in options:
+                for opt in all_current_options:
                     if opt["value"] == v:
                         formatted_v = opt.copy()
                         if isinstance(v, str):
@@ -312,10 +402,21 @@ def dynamic_multiselect_options(user_in: str, selections, cached_options):
                         break
 
         # Combine results, limiting to 100 items but always including selections
+        # ENSURE ORGS ARE ALWAYS INCLUDED: Separate orgs and repos, then combine smartly
+        orgs_in_results = [opt for opt in formatted_opts if isinstance(opt["value"], str)]
+        repos_in_results = [opt for opt in formatted_opts if isinstance(opt["value"], int)]
+
         if len(formatted_opts) < 100:
             result = formatted_opts
         else:
-            result = formatted_opts[:100]
+            # Always include all orgs (there are usually very few)
+            # Then fill remaining slots with repos
+            remaining_slots = 100 - len(orgs_in_results)
+            if remaining_slots > 0:
+                result = orgs_in_results + repos_in_results[:remaining_slots]
+            else:
+                # Edge case: more than 100 orgs (very unlikely)
+                result = orgs_in_results[:100]
 
         # Add selected options that aren't already in the results
         selected_values = [opt["value"] for opt in result]
@@ -325,7 +426,8 @@ def dynamic_multiselect_options(user_in: str, selections, cached_options):
 
         end_time = time.time()
         logging.info(f"Search completed in {end_time - start_time:.2f} seconds")
-        logging.info(f"Returning {len(result)} options to dropdown")
+        logging.info(f"Returning {len(result)} options to dropdown (fallback used: {use_server_fallback})")
+
         return [result]
 
     except Exception as e:
@@ -586,7 +688,6 @@ def initialize_cache(_):
                     decode_responses=True,
                 )
                 users_cache.ping()
-                logging.info("Successfully connected to Redis")
 
                 if users_cache.exists(f"{current_user.get_id()}_group_options"):
                     user_options = json.loads(users_cache.get(f"{current_user.get_id()}_group_options"))

--- a/8Knot/pages/index/index_layout.py
+++ b/8Knot/pages/index/index_layout.py
@@ -260,6 +260,17 @@ search_bar = html.Div(
                             className="searchbar-dropdown",
                         ),
                         dbc.Alert(
+                            children='Please ensure that your spelling is correct. \
+                                If your selection definitely isn\'t present, please request that \
+                                it be loaded using the help button "REPO/ORG Request" \
+                                in the bottom right corner of the screen.',
+                            id="help-alert",
+                            dismissable=True,
+                            fade=True,
+                            is_open=False,
+                            color="info",
+                        ),
+                        dbc.Alert(
                             children="List of repos",
                             id="repo-list-alert",
                             dismissable=True,

--- a/8Knot/pages/index/index_layout.py
+++ b/8Knot/pages/index/index_layout.py
@@ -259,19 +259,6 @@ search_bar = html.Div(
                             # Removed: dropdownPosition and transitionDuration no longer supported in v2.1.0
                             className="searchbar-dropdown",
                         ),
-                        # Add search status indicator
-                        html.Div(id="search-status", className="search-status-indicator", style={"display": "none"}),
-                        dbc.Alert(
-                            children='Please ensure that your spelling is correct. \
-                                If your selection definitely isn\'t present, please request that \
-                                it be loaded using the help button "REPO/ORG Request" \
-                                in the bottom right corner of the screen.',
-                            id="help-alert",
-                            dismissable=True,
-                            fade=True,
-                            is_open=False,
-                            color="info",
-                        ),
                         dbc.Alert(
                             children="List of repos",
                             id="repo-list-alert",

--- a/8Knot/pages/index/search_utils.py
+++ b/8Knot/pages/index/search_utils.py
@@ -78,10 +78,10 @@ def search_with_fuzzy_matching(query: str, options: List[Dict[str, Any]], thresh
     if remaining_options:
         # Use fuzzy matching for remaining options
         matches = process.extract(
-            query,
+            query_lower,  # Use lowercased query
             [opt["label"] for opt in remaining_options],
             scorer=fuzz.token_sort_ratio,
-            processor=str.lower,  # Case-insensitive matching
+            processor=str.lower,
             limit=None,  # Remove the 100 limit to get all matches
             score_cutoff=threshold_100,
         )


### PR DESCRIPTION
In the current implementation of the search bar, a bug was found on the client-side cache and when to fallback to server requests. The application was only going to server requests where there was no cache at all, which meant that if the cache was available, all search would rely on the cache downloaded options. 
This PR current implementation still implements client-side caching downloading a limited number of the latest repos and orgs, however, when the user search for specific repos not found in the cache, the application now goes searching through server requests.
