### PR TITLE
Resolving issue #793 - Increase Nginx default Timeout

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,6 +8,7 @@ http {
 	      access_log  /dev/null; # disables logging on every request
               location / {
                 proxy_pass http://app-server:8080;
+                proxy_read_timeout 600s;        # 10 minutes - allow long-running Dash callbacks
               }
         }
 }


### PR DESCRIPTION
This PR resolves the issue #793 

The Nginx default timeout (60s) is now increased to allow for Dash long-running callbacks and to get aligned with the new celery workers soft limit timeouts.