### PR TITLE
Hot Reload for Python Dash Application

### DIFF
--- a/8Knot/app.py
+++ b/8Knot/app.py
@@ -51,7 +51,7 @@ augur.multiselect_startup()
 import pages.index.index_callbacks as index_callbacks
 
 # Import testing utilities for enhanced error detection in CI
-if os.getenv("8KNOT_DEBUG", "False") == "True":
+if os.getenv("DEBUG_8KNOT", "False") == "True":
     import testing_utils
 
     testing_utils.log_service_status()
@@ -91,8 +91,6 @@ server = app.server
 server = _login.configure_server_login(server)
 
 """HEALTH CHECK ENDPOINT"""
-
-
 @server.route("/health")
 def health_check():
     """Simple health check endpoint for CI/CD testing"""
@@ -116,7 +114,7 @@ app.layout = layout
 """DASH STARTUP PARAMETERS"""
 
 if os.getenv("8KNOT_DEBUG", "False") == "True":
-    app.enable_dev_tools(dev_tools_ui=True, dev_tools_hot_reload=False)
+    app.enable_dev_tools(dev_tools_ui=True, dev_tools_hot_reload=True)
 
 """GITHUB BOTS LIST"""
 bots_list = bots.get_bots_list()

--- a/8Knot/entrypoint.sh
+++ b/8Knot/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Entrypoint for app-server: chooses dev or prod mode based on GUNICORN_RELOAD env var
+
+if [ "$DEBUG_8KNOT" = "True" ]; then
+  echo "[Entrypoint] Development mode: enabling --reload and mounting source code."
+  exec gunicorn --reload --bind :8080 app:server --workers 1 --threads 2 --timeout 300 --keep-alive 5
+else
+  echo "[Entrypoint] Production mode: running without --reload."
+  exec gunicorn --bind :8080 app:server --workers 1 --threads 2 --timeout 300 --keep-alive 5
+fi

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ These credentials are suitable for development, but please replace any secrets w
     AUGUR_PORT=5432
     AUGUR_SCHEMA=augur_data
     AUGUR_USERNAME=coup
-    8KNOT_DEBUG=True
+    DEBUG_8KNOT=True
     REDIS_PASSWORD=1234
     DEFAULT_SEARCHBAR_LABEL=chaoss
     POSTGRES_PASSWORD=somepassword
@@ -176,6 +176,8 @@ These credentials are suitable for development, but please replace any secrets w
 
 8Knot doesn't handle user accounts or data collection requests on its own. To support these features, you'll need to add the
 following additional configuration to your `env.list` file.
+
+Setting the `DEBUG_8KNOT` environmental variable to True will enable hot reloading of the Dash application, after any change to a file inside the 8Knot/ directory.
 
 You'll need to register your 8Knot instance with an Augur front-end application to get an `AUGUR_APP_ID` and an `AUGUR_CLIENT_SECRET`.
 All parameters wrapped in `< >` will need to be replaced below. `<endpoint>` variables refer to the host of the Augur front-end that

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,21 +28,9 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile
-    command:
-      [
-        "gunicorn",
-        "--bind",
-        ":8080",
-        "app:server",
-        "--workers",
-        "1",
-        "--threads",
-        "2",
-        "--timeout",
-        "300",
-        "--keep-alive",
-        "5"
-      ]
+    entrypoint: ["sh", "./entrypoint.sh"]
+    volumes:
+      - ./8Knot:/opt/app-root/src/
     # ports:
     #   - 8080:8080
     depends_on:


### PR DESCRIPTION
Allows hot reloading of the app server so that a rebuild is not necessary for small changes in the Python Dash Application.