### PR TITLE
Removing querying all repos from startup

### DIFF
--- a/8Knot/app.py
+++ b/8Knot/app.py
@@ -44,8 +44,9 @@ except KeyError:
 except SQLAlchemyError:
     sys.exit(1)
 
+# NOTE: multiselect_startup() disabled for faster startup - options loaded on-demand
 # grab list of projects and orgs from Augur database.
-augur.multiselect_startup()
+# augur.multiselect_startup()
 
 
 """IMPORT AFTER GLOBAL VARIABLES SET"""

--- a/8Knot/cache_manager/cache_facade.py
+++ b/8Knot/cache_manager/cache_facade.py
@@ -123,6 +123,10 @@ def get_uncached(func_name: str, repolist: list[int]) -> list[int]:  # or None
 
     Returns a list of repos that AREN'T resident in cache.
     """
+    # Handle None or empty repolist
+    if not repolist:
+        return []
+
     with pg.connect(cache_cx_string) as cache_conn:
         with cache_conn.cursor() as cache_cur:
             composed_query = pg_sql.SQL(
@@ -169,6 +173,12 @@ def caching_wrapper(func_name: str, query: str, repolist: list[int], n_repolist_
     Returns:
         _type_: None
     """
+
+    # Handle None or empty repolist
+    if not repolist:
+        logging.warning(f"{func_name} COLLECTION - NO REPOS TO CACHE")
+        return 0
+
     try:
         # STEP 1: Which repos need to be queried for?
         #           some might already be in cache.
@@ -210,6 +220,10 @@ def retrieve_from_cache(
     Results are retrieved by a DataFrame, so column names
     may need to be overridden by calling function.
     """
+
+    # Handle None or empty repolist
+    if not repolist:
+        return pd.DataFrame()
 
     # GET ALL DATA FROM POSTGRES CACHE
     df = None

--- a/8Knot/pages/index/index_layout.py
+++ b/8Knot/pages/index/index_layout.py
@@ -253,7 +253,7 @@ search_bar = html.Div(
                             variant="filled",
                             debounce=100,  # debounce time for the search input, since we're implementing client-side caching, we can use a faster debounce
                             data=[augur.initial_multiselect_option()],
-                            value=[augur.initial_multiselect_option()["value"]],
+                            value=[augur.initial_multiselect_option()["value"]],  # Pre-select chaoss org at startup
                             style={"fontSize": 16, "zIndex": 9999},  # Updated: moved zIndex to style
                             maxDropdownHeight=300,  # limits the dropdown menu's height to 300px
                             # Removed: dropdownPosition and transitionDuration no longer supported in v2.1.0
@@ -323,7 +323,9 @@ search_bar = html.Div(
 layout = dbc.Container(
     [
         # componets to store data from queries
-        dcc.Store(id="repo-choices", storage_type="session", data=[]),
+        dcc.Store(
+            id="repo-choices", storage_type="session", data=None
+        ),  # Changed from [] to None to prevent startup callbacks
         # components to store job-ids for the worker queue
         dcc.Store(id="job-ids", storage_type="session", data=[]),
         dcc.Store(id="user-group-loading-signal", data="", storage_type="memory"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
     env_file:
       - .env
     environment:
+      - DEFAULT_SEARCHBAR_LABEL=chaoss  # Default org to show in searchbar at startup
       - EIGHTKNOT_SEARCHBAR_OPTS_SORT=shortest  # Try different options: shortest, longest, alphabetical
       - EIGHTKNOT_SEARCHBAR_OPTS_MAX_RESULTS=5500  # Maximum number of results to return (org and repo)
       - EIGHTKNOT_SEARCHBAR_OPTS_MAX_REPOS=5000  # Max number of repos


### PR DESCRIPTION
This PR aims to have a faster startup, by removing the synchronous querying of repos, and switching to an asynchronous query once the UI has already been started.