### PR TITLE
Fixing issue on Nightly Dependency Workflow - Upgrading deprecated versions to latest ones

### DIFF
--- a/.github/workflows/nightly-dependency-test.yml
+++ b/.github/workflows/nightly-dependency-test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -172,7 +172,7 @@ jobs:
 
       - name: Save artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nightly-test-artifacts
           path: |
@@ -183,7 +183,7 @@ jobs:
 
       - name: Create GitHub issue on failure
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const today = new Date().toISOString().split('T')[0];


### PR DESCRIPTION
This PR resolves the issue of the nightly_dependency Github action by upgrading the deprecated versions on it.