### PR TITLE
Nightly dependency workflow logs error build fix

### DIFF
--- a/.github/workflows/nightly-dependency-test.yml
+++ b/.github/workflows/nightly-dependency-test.yml
@@ -43,9 +43,13 @@ jobs:
           # Create backup of original requirements
           cp requirements.txt requirements.txt.backup
 
-          # Remove version pins to get latest versions
+          # Remove version pins to get latest versions (except for packages with breaking changes)
           sed 's/==.*$//' requirements.txt > requirements_latest.txt
           sed 's/>=.*$//' requirements_latest.txt > requirements_unpinned.txt
+
+          # Keep dash-mantine-components pinned due to breaking API changes between versions
+          grep 'dash-mantine-components==' requirements.txt.backup >> requirements_unpinned.txt || true
+
           mv requirements_unpinned.txt requirements.txt
 
           echo "Updated requirements.txt to use latest versions:"

--- a/8Knot/pages/index/index_layout.py
+++ b/8Knot/pages/index/index_layout.py
@@ -254,11 +254,9 @@ search_bar = html.Div(
                             debounce=100,  # debounce time for the search input, since we're implementing client-side caching, we can use a faster debounce
                             data=[augur.initial_multiselect_option()],
                             value=[augur.initial_multiselect_option()["value"]],
-                            style={"fontSize": 16},
+                            style={"fontSize": 16, "zIndex": 9999},  # Updated: moved zIndex to style
                             maxDropdownHeight=300,  # limits the dropdown menu's height to 300px
-                            zIndex=9999,  # ensures the dropdown menu is on top of other elements
-                            dropdownPosition="bottom",  # forces the dropdown to open downwards
-                            transitionDuration=150,  # transition duration for the dropdown menu
+                            # Removed: dropdownPosition and transitionDuration no longer supported in v2.1.0
                             className="searchbar-dropdown",
                         ),
                         # Add search status indicator


### PR DESCRIPTION
This PR fix the error/break on the current build with latest dependencies installed as shown by the Nightly dependency workflow. 

The error consisted in the 'dash-mantime-components==0.12.1' which after unpinned and upgraded to version 2.1.0 did not have previous keywords as used in the previous version (dropdownposition, transitiondurantion, nothingfound)

