### PR TITLE
Removeold fuzzywuzzy dependency

### DIFF
--- a/8Knot/pages/affiliation/visualizations/gh_org_affiliation.py
+++ b/8Knot/pages/affiliation/visualizations/gh_org_affiliation.py
@@ -12,7 +12,7 @@ from queries.affiliation_query import affiliation_query as aq
 from pages.utils.job_utils import nodata_graph
 import time
 import datetime as dt
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 import app
 import cache_manager.cache_facade as cf
 
@@ -242,7 +242,7 @@ def fuzzy_match(df, name):
     necessary for the loop to change the company name if there is a match. 70 is the match value
     threshold for the partial ratio to be considered a match
     """
-    matches = df.apply(lambda row: (fuzz.partial_ratio(row["company_name"], name) >= 70), axis=1)
+    matches = df.apply(lambda row: (fuzz.partial_ratio(row["company_name"], name, score_cutoff=70) >= 70), axis=1)
     return [i for i, x in enumerate(matches) if x]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "dash-mantine-components~=2.2",
     "flask==3.0.2",
     "flask-login==0.6.3",
-    "fuzzywuzzy==0.18.0",
     "gunicorn==21.2.0",
     "numpy==1.26.4",
     "pandas==2.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,6 @@ dependencies = [
     { name = "dash-mantine-components" },
     { name = "flask" },
     { name = "flask-login" },
-    { name = "fuzzywuzzy" },
     { name = "gunicorn" },
     { name = "numpy" },
     { name = "pandas" },
@@ -43,7 +42,6 @@ requires-dist = [
     { name = "dash-mantine-components", specifier = "~=2.2" },
     { name = "flask", specifier = "==3.0.2" },
     { name = "flask-login", specifier = "==0.6.3" },
-    { name = "fuzzywuzzy", specifier = "==0.18.0" },
     { name = "gunicorn", specifier = "==21.2.0" },
     { name = "numpy", specifier = "==1.26.4" },
     { name = "pandas", specifier = "==2.2.0" },
@@ -368,15 +366,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/6e/2f4e13e373bb49e68c02c51ceadd22d172715a06716f9299d9df01b6ddb2/Flask-Login-0.6.3.tar.gz", hash = "sha256:5e23d14a607ef12806c699590b89d0f0e0d67baeec599d75947bf9c147330333", size = 48834, upload-time = "2023-10-30T14:53:21.151Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl", hash = "sha256:849b25b82a436bf830a054e74214074af59097171562ab10bfa999e6b78aae5d", size = 17303, upload-time = "2023-10-30T14:53:19.636Z" },
-]
-
-[[package]]
-name = "fuzzywuzzy"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/4b/0a002eea91be6048a2b5d53c5f1b4dafd57ba2e36eea961d05086d7c28ce/fuzzywuzzy-0.18.0.tar.gz", hash = "sha256:45016e92264780e58972dca1b3d939ac864b78437422beecebb3095f8efd00e8", size = 28888, upload-time = "2020-02-13T21:06:27.054Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/ff/74f23998ad2f93b945c0309f825be92e04e0348e062026998b5eefef4c33/fuzzywuzzy-0.18.0-py2.py3-none-any.whl", hash = "sha256:928244b28db720d1e0ee7587acf660ea49d7e4c632569cad4f1cd7e68a5f0993", size = 18272, upload-time = "2020-02-13T21:06:25.209Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
this replaces an old. likely unmaintained fuzzing library so that the codebase uses a single library

fixes #851 