### PR TITLE
enable integer typecasts to handle nulls

### DIFF
--- a/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
+++ b/8Knot/pages/repo_overview/visualizations/ossf_scorecard.py
@@ -98,8 +98,12 @@ def toggle_popover(n, is_open):
     background=True,
 )
 def ossf_scorecard(repo: str):
+
+    if repo is not None:
+        repo = int(repo)
+
     # wait for data to asynchronously download and become available.
-    while not_cached := cf.get_uncached(func_name=osq.__name__, repolist=[int(repo)]):
+    while not_cached := cf.get_uncached(func_name=osq.__name__, repolist=[repo]):
         logging.warning(f"{VIZ_ID}- WAITING ON DATA TO BECOME AVAILABLE")
         time.sleep(0.5)
 
@@ -109,7 +113,7 @@ def ossf_scorecard(repo: str):
     # GET ALL DATA FROM POSTGRES CACHE
     df = cf.retrieve_from_cache(
         tablename=osq.__name__,
-        repolist=[int(repo)],
+        repolist=[repo],
     )
 
     # test if there is data

--- a/8Knot/pages/repo_overview/visualizations/repo_general_info.py
+++ b/8Knot/pages/repo_overview/visualizations/repo_general_info.py
@@ -80,11 +80,14 @@ def toggle_popover(n, is_open):
 )
 def repo_general_info(repo):
 
+    if repo is not None:
+        repo = int(repo)
+
     logging.warning(f"{VIZ_ID} - START")
     start = time.perf_counter()
 
     # get dataframes of data from cache
-    df_repo_files, df_repo_info, df_releases = multi_query_helper([int(repo)])
+    df_repo_files, df_repo_info, df_releases = multi_query_helper([repo])
 
     # test if there is data
     if df_repo_files.empty and df_repo_info.empty and df_releases.empty:


### PR DESCRIPTION
i noticed that when loading a repo that isnt cached, the ossf scorecard and repo info tables seem to have issues with the `int()` typecast.

I suspect this is because a null value is getting passed in as the set repo (potentially a race condition between the callback that sets the selected repo to the default value and the callbacks processing the graphs). This causes the typecasts to fail loudly.

This PR allows null values to pass through (and hopefully be handled as they would have prior to the mantine update that caused all this