### PR TITLE
Restore Dropdown styles

### DIFF
--- a/8Knot/assets/color.css
+++ b/8Knot/assets/color.css
@@ -263,7 +263,7 @@ div.dark-card {
 
 
 /* Fix for the vertical bar issue */
-.dbc input:not([type=radio]):not([type=checkbox]).DateInput_input {
+.dbc input:not([type=radio]):not([type=checkbox]) {
   color: var(--bs-body-color) !important;
   background-color: #404040 !important;
 }

--- a/8Knot/assets/color.css
+++ b/8Knot/assets/color.css
@@ -243,14 +243,35 @@ div.dark-card {
 }
 
 /* =============================================================================
-   DATE PICKER COMPONENTS
+   DROPDOWN COMPONENTS
 ============================================================================= */
+
+/* Dark Dropdown Box Styling */
+.dark-dropdown .Select-control,
+.dark-dropdown .Select-control:hover {
+  background-color: var(--multiselect-hover-bg) !important;
+  border-color: var(--multiselect-hover-bg) !important;
+  color: white !important;
+  min-width: 150px !important;
+}
+
+/* Dark Dropdown Placeholder Styling */
+.dark-dropdown .Select-placeholder,
+.dark-dropdown .Select-value-label {
+  color: white !important;
+}
+
 
 /* Fix for the vertical bar issue */
 .dbc input:not([type=radio]):not([type=checkbox]).DateInput_input {
   color: var(--bs-body-color) !important;
   background-color: #404040 !important;
 }
+
+
+/* =============================================================================
+   DATE PICKER COMPONENTS
+============================================================================= */
 
 /**
  * Date Picker Dark Theme


### PR DESCRIPTION
This un-deletes the dropdown bar styles I removed in #947 (still unsure where the box containing the possible selection items gets its styles though)

<img width="426" height="275" alt="Screenshot_20251002_132516" src="https://github.com/user-attachments/assets/034ec1b6-95e5-4af7-8a22-be4d8604b980" />


Fixes #975 

Is this what was intended? or is there more styling that is needed for the dropdown styles?