### PR TITLE
Added input validation for repos

### DIFF
--- a/8Knot/queries/package_version_query.py
+++ b/8Knot/queries/package_version_query.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List, Optional
 import cache_manager.cache_facade as cf
 from app import celery_app
 
@@ -6,62 +7,71 @@ from app import celery_app
 @celery_app.task(
     bind=True,
     autoretry_for=(Exception,),
-    exponential_backoff=2,
+    retry_backoff=2,
     retry_kwargs={"max_retries": 5},
     retry_jitter=True,
 )
-def package_version_query(self, repos):
+def package_version_query(self, repos: List[int]) -> Optional[dict]:
     """
-    (Worker Query)
+    Celery Worker Task:
     Executes SQL query against Augur database for package dependency versioning data.
 
     Args:
-    -----
-        repos ([int]): repos that SQL query is executed on.
+        repos (List[int]): Repository IDs
 
     Returns:
-    --------
-        dict: Results from SQL query, interpreted from pd.to_dict('records')
-
+        Optional[dict]: Cached query results
     """
-    logging.warning(f"{package_version_query.__name__} COLLECTION - START")
 
-    if len(repos) == 0:
+    logging.info(f"{package_version_query.__name__} - START")
+
+    # Validate input
+    if not repos:
+        logging.info("No repositories provided. Skipping query.")
         return None
 
+    if not isinstance(repos, list):
+        raise ValueError("repos must be a list of repository IDs")
+
+    # Convert to tuple for safe SQL IN usage
+    repos_tuple = tuple(repos)
+
     query_string = """
-                SELECT
-                    rdl.repo_id as id,
-                    rdl.name,
-                    rdl.current_release_date,
-                    rdl.latest_release_date,
-                    rdl.libyear,
-                    case -- categorize the dependency out-of-date-edness;
-                            WHEN rdl.libyear >= 1.0 THEN 'Greater than a year'
-                            WHEN rdl.libyear < 1.0 and rdl.libyear > 0.5 THEN '6 months to year'
-                            when rdl.libyear < 0.5 and rdl.libyear > 0 then 'Less than 6 months'
-                            when rdl.libyear = 0 then 'Up to date'
-                            else 'Unclear version history'
-                    END as dep_age
-                FROM
-                    repo_deps_libyear rdl
-                WHERE
-                    repo_id IN %s
-                    AND
-                    (rdl.repo_id, rdl.data_collection_date) IN (
-                        SELECT DISTINCT ON (repo_id)
-                            repo_id, data_collection_date
-                        FROM repo_deps_libyear
-                        WHERE
-                            repo_id IN %s
-                        ORDER BY repo_id, data_collection_date DESC
-                    ) AND
-                    rdl.libyear >= 0
-                """
+        WITH latest_repo_data AS (
+            SELECT DISTINCT ON (repo_id)
+                repo_id,
+                data_collection_date
+            FROM repo_deps_libyear
+            WHERE repo_id IN %s
+            ORDER BY repo_id, data_collection_date DESC
+        )
+        SELECT
+            rdl.repo_id AS id,
+            rdl.name,
+            rdl.current_release_date,
+            rdl.latest_release_date,
+            rdl.libyear,
+            CASE
+                WHEN rdl.libyear >= 1.0 THEN 'Greater than a year'
+                WHEN rdl.libyear > 0.5 THEN '6 months to year'
+                WHEN rdl.libyear > 0 THEN 'Less than 6 months'
+                WHEN rdl.libyear = 0 THEN 'Up to date'
+                ELSE 'Unclear version history'
+            END AS dep_age
+        FROM repo_deps_libyear rdl
+        JOIN latest_repo_data lrd
+            ON rdl.repo_id = lrd.repo_id
+            AND rdl.data_collection_date = lrd.data_collection_date
+        WHERE rdl.libyear >= 0
+    """
 
     func_name = package_version_query.__name__
 
-    # raises Exception on failure. Returns nothing.
-    cf.caching_wrapper(func_name=func_name, query=query_string, repolist=repos, n_repolist_uses=2)
+    cf.caching_wrapper(
+        func_name=func_name,
+        query=query_string,
+        repolist=repos_tuple,
+        n_repolist_uses=1,
+    )
 
-    logging.warning(f"{package_version_query.__name__} COLLECTION - END")
+    logging.info(f"{package_version_query.__name__} - END")


### PR DESCRIPTION
Added input validation for repos.
Converted repos to tuple to ensure safe SQL execution.
Rewrote subquery using CTE (WITH latest_repo_data) for clarity and optimization.
Reduced redundant repo_id IN %s usage from 2 to 1.
Replaced logging.warning with logging.info for proper log levels.
Improved CASE logic readability.
