### PR TITLE
Add .gitattributes for consistent line ending handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Set default behavior to automatically normalize line endings
+* text=auto
+
+# Python files should always use LF line endings
+*.py text eol=lf
+
+# Shell scripts should always use LF line endings
+*.sh text eol=lf
+
+# Markdown files should always use LF line endings
+*.md text eol=lf
+
+# YAML files should always use LF line endings
+*.yaml text eol=lf
+*.yml text eol=lf
+
+# Binary files should not be modified
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,30 @@
 *.yaml text eol=lf
 *.yml text eol=lf
 
+# Dockerfiles should always use LF line endings
+Dockerfile text eol=lf
+Dockerfile.* text eol=lf
+*.Dockerfile text eol=lf
+*.dockerfile text eol=lf
+
+# SQL files should always use LF line endings
+*.sql text eol=lf
+
+# TOML files should always use LF line endings
+*.toml text eol=lf
+
+# CSS/SVG/HTML files should always use LF line endings
+*.css text eol=lf
+*.svg text eol=lf
+*.html text eol=lf
+
+# JSON files should always use LF line endings
+*.json text eol=lf
+
+# Config and lock files should always use LF line endings
+*.conf text eol=lf
+*.lock text eol=lf
+
 # Binary files should not be modified
 *.png binary
 *.jpg binary


### PR DESCRIPTION
### Pull Request Change Description

Adds a `.gitattributes` file to enforce consistent LF line endings across the repository, addressing issues caused by Windows-style CRLF line endings being introduced on Windows machines (as described in #1062).

- `* text=auto` — default automatic normalization for all text files
- `*.py`, `*.sh`, `*.md`, `*.yaml`, `*.yml` — explicitly enforced LF (`eol=lf`)
- Binary files (images) marked as `binary` to prevent modification

Closes #1062

### Generative AI disclosure

- [x] This contribution was assisted or created by Generative AI tools.
  - What tools were used? Kiro (AI-powered dev environment)
  - How were these tools used? Generated the .gitattributes file content
  - Did you review these outputs before submitting this PR? Yes

