### PR TITLE
Add label filter to Issues Over Time graph

### DIFF
--- a/8Knot/cache_manager/db_init.py
+++ b/8Knot/cache_manager/db_init.py
@@ -206,7 +206,8 @@ def _create_application_tables() -> None:
                 reporter_id text,
                 issue_closer text,
                 created_at text,
-                closed_at text
+                closed_at text,
+                labels text
             )
             """
         )

--- a/8Knot/pages/contributions/visualizations/issue_staleness.py
+++ b/8Knot/pages/contributions/visualizations/issue_staleness.py
@@ -106,6 +106,28 @@ gc_issue_staleness = VisualizationAIO(
             ],
             align="center",
         ),
+        dbc.Row(
+            [
+                dbc.Label(
+                    "Issue Filter:",
+                    html_for=f"bug-filter-{PAGE}-{VIZ_ID}",
+                    width={"size": "auto"},
+                ),
+                dbc.Col(
+                    dbc.RadioItems(
+                        id=f"bug-filter-{PAGE}-{VIZ_ID}",
+                        options=[
+                            {"label": "All Issues", "value": "all"},
+                            {"label": "Bugs Only", "value": "bug"},
+                        ],
+                        value="all",
+                        inline=True,
+                        className="custom-radio-buttons",
+                    ),
+                ),
+            ],
+            align="center",
+        ),
     ],
     class_name="dark-card",
     id="issue-staleness",
@@ -120,10 +142,11 @@ gc_issue_staleness = VisualizationAIO(
         Input(f"date-interval-{PAGE}-{VIZ_ID}", "value"),
         Input(f"staling-days-{PAGE}-{VIZ_ID}", "value"),
         Input(f"stale-days-{PAGE}-{VIZ_ID}", "value"),
+        Input(f"bug-filter-{PAGE}-{VIZ_ID}", "value"),
     ],
     background=True,
 )
-def new_staling_issues_graph(repolist, interval, staling_interval, stale_interval):
+def new_staling_issues_graph(repolist, interval, staling_interval, stale_interval, bug_filter):
     # conditional for the intervals to be valid options
     if staling_interval > stale_interval:
         return dash.no_update, True
@@ -156,7 +179,7 @@ def new_staling_issues_graph(repolist, interval, staling_interval, stale_interva
         return nodata_graph, False
 
     # function for all data pre processing
-    df_status = process_data(df, interval, staling_interval, stale_interval)
+    df_status = process_data(df, interval, staling_interval, stale_interval, bug_filter)
 
     fig = create_figure(df_status, interval)
 
@@ -164,10 +187,17 @@ def new_staling_issues_graph(repolist, interval, staling_interval, stale_interva
     return fig, False
 
 
-def process_data(df: pd.DataFrame, interval, staling_interval, stale_interval):
+def process_data(df: pd.DataFrame, interval, staling_interval, stale_interval, bug_filter):
     # convert to datetime objects rather than strings
     df["created_at"] = pd.to_datetime(df["created_at"], utc=True)
     df["closed_at"] = pd.to_datetime(df["closed_at"], utc=True)
+
+    # filter to bug-tagged issues only if requested
+    if bug_filter == "bug":
+        if "labels" not in df.columns:
+            logging.warning("ISSUE STALENESS - 'labels' column not found in cache, skipping bug filter")
+        else:
+            df = df[df["labels"].str.contains("bug", case=False, na=False)]
 
     # order values chronologically by creation date
     df = df.sort_values(by="created_at", axis=0, ascending=True)

--- a/8Knot/pages/contributions/visualizations/issues_over_time.py
+++ b/8Knot/pages/contributions/visualizations/issues_over_time.py
@@ -153,7 +153,10 @@ def process_data(df: pd.DataFrame, interval, start_date, end_date, label_filter)
 
     # filter to bug-tagged issues only if requested
     if label_filter == "bug":
-        df = df[df["labels"].str.contains("bug", case=False, na=False)]
+        if "labels" not in df.columns:
+            logging.warning("ISSUES OVER TIME - 'labels' column not found in cache, skipping label filter")
+        else:
+            df = df[df["labels"].str.contains("bug", case=False, na=False)]
 
     # order values chronologically by creation date
     df = df.sort_values(by="created_at", axis=0, ascending=True)

--- a/8Knot/pages/contributions/visualizations/issues_over_time.py
+++ b/8Knot/pages/contributions/visualizations/issues_over_time.py
@@ -75,6 +75,28 @@ gc_issues_over_time = VisualizationAIO(
                 width=7,
             ),
         ),
+        dbc.Row(
+            [
+                dbc.Label(
+                    "Issue Filter:",
+                    html_for=f"label-filter-{PAGE}-{VIZ_ID}",
+                    width={"size": "auto"},
+                ),
+                dbc.Col(
+                    dbc.RadioItems(
+                        id=f"label-filter-{PAGE}-{VIZ_ID}",
+                        options=[
+                            {"label": "All Issues", "value": "all"},
+                            {"label": "Bugs Only", "value": "bug"},
+                        ],
+                        value="all",
+                        inline=True,
+                        className="custom-radio-buttons",
+                    ),
+                ),
+            ],
+            align="center",
+        ),
     ],
     class_name="dark-card",
     id="issues-over-time",
@@ -89,10 +111,11 @@ gc_issues_over_time = VisualizationAIO(
         Input(f"date-interval-{PAGE}-{VIZ_ID}", "value"),
         Input(f"date-picker-range-{PAGE}-{VIZ_ID}", "start_date"),
         Input(f"date-picker-range-{PAGE}-{VIZ_ID}", "end_date"),
+        Input(f"label-filter-{PAGE}-{VIZ_ID}", "value"),
     ],
     background=True,
 )
-def issues_over_time_graph(repolist, interval, start_date, end_date):
+def issues_over_time_graph(repolist, interval, start_date, end_date, label_filter):
     # wait for data to asynchronously download and become available.
     while not_cached := cf.get_uncached(func_name=iq.__name__, repolist=repolist):
         logging.warning(f"ISSUES OVER TIME - WAITING ON DATA TO BECOME AVAILABLE")
@@ -114,7 +137,7 @@ def issues_over_time_graph(repolist, interval, start_date, end_date):
         return nodata_graph
 
     # function for all data pre processing
-    df_created, df_closed, df_open = process_data(df, interval, start_date, end_date)
+    df_created, df_closed, df_open = process_data(df, interval, start_date, end_date, label_filter)
 
     fig = create_figure(df_created, df_closed, df_open, interval)
 
@@ -123,10 +146,14 @@ def issues_over_time_graph(repolist, interval, start_date, end_date):
     return fig
 
 
-def process_data(df: pd.DataFrame, interval, start_date, end_date):
+def process_data(df: pd.DataFrame, interval, start_date, end_date, label_filter):
     # convert to datetime objects rather than strings
     df["created_at"] = pd.to_datetime(df["created_at"], utc=False)
     df["closed_at"] = pd.to_datetime(df["closed_at"], utc=False)
+
+    # filter to bug-tagged issues only if requested
+    if label_filter == "bug":
+        df = df[df["labels"].str.contains("bug", case=False, na=False)]
 
     # order values chronologically by creation date
     df = df.sort_values(by="created_at", axis=0, ascending=True)

--- a/8Knot/queries/issues_query.py
+++ b/8Knot/queries/issues_query.py
@@ -40,18 +40,29 @@ def issues_query(self, repos):
                         left(i.cntrb_id::text, 15) as issue_closer,
                         -- timestamps are not timestamptz
                         i.created_at,
-                        i.closed_at
+                        i.closed_at,
+                        STRING_AGG(il.label_text, ', ') AS labels
                     FROM
-                        repo r,
-                        issues i
+                        repo r
+                        JOIN issues i ON r.repo_id = i.repo_id
+                        LEFT JOIN issue_labels il ON i.issue_id = il.issue_id
                     WHERE
-                        r.repo_id = i.repo_id AND
                         r.repo_id in %s
                         and i.pull_request_id is null
                         and i.created_at < now()
                         and (i.closed_at < now() or i.closed_at IS NULL)
                         -- have to accept NULL values because issues could still be open, or unassigned,
                         -- and still be acceptable.
+                    GROUP BY
+                        r.repo_id,
+                        r.repo_name,
+                        i.issue_id,
+                        i.gh_issue_number,
+                        i.gh_issue_id,
+                        i.reporter_id,
+                        i.cntrb_id,
+                        i.created_at,
+                        i.closed_at
                     ORDER BY i.created_at
                     """
 


### PR DESCRIPTION
### Pull Request Change Description

Adds an "Issue Filter" control to the Issues Over Time visualization, allowing users to toggle between viewing all issues or only those tagged with a "bug" label.

**Changes:**
- Added a `RadioItems` control ("All Issues" / "Bugs Only") to the visualization controls
- Wired it into the callback as a new `Input`
- Filters the DataFrame in `process_data()` on the `labels` column when "Bugs Only" is selected

**Note:** This relies on the `labels` column and `issue_labels` JOIN added to `issues_query` in PR #[your #1085 PR number]. Both PRs should be reviewed together or this one merged after that one.

Closes #254

### Generative AI disclosure
- [x] This contribution was assisted or created by Generative AI tools.
  - What tools were used? Kiro (AI-powered dev environment)
  - How were these tools used? Code generation following existing patterns in the codebase
  - Did you review these outputs before submitting this PR? Yes

