### PR TITLE
fix Shareable URL fragment scrolling bug

### DIFF
--- a/8Knot/assets/scroll_to_anchor.js
+++ b/8Knot/assets/scroll_to_anchor.js
@@ -1,0 +1,45 @@
+/*
+ * Scroll the URL's #fragment target into view. Registered as a Dash clientside
+ * callback on url.hash — see index_callbacks.py.
+ *
+ * The target ids already exist: each graph card carries a nav id (the
+ * VisualizationAIO `id=` set in the viz files), and the codebase heatmaps use
+ * the ids on their layout rows. This adds NO ids — it only fixes WHEN the
+ * scroll happens:
+ *   - Dash renders the page client-side AFTER the browser's one native hash
+ *     scroll, so at that moment the target element does not exist yet.
+ *   - Graphs above the target then load asynchronously and reflow the page,
+ *     moving the target. That settle time is variable and unbounded (cached
+ *     vs live data, count/kind of graphs above, network), so no single delay
+ *     is correct — too short misses the slow tail, too long stalls every page.
+ *
+ * So we keep the target pinned at center on a short interval until the layout
+ * settles: each tick is a no-op before the element exists and a no-op once it
+ * is centered, and it self-corrects instantly as the page reflows. It stops at
+ * the first user scroll (armed only after our first scroll, so leftover scroll
+ * momentum can't cancel it early) or after a 6s cap.
+ */
+window.dash_clientside = Object.assign({}, window.dash_clientside, {
+    eightknot: {
+        scroll_to_anchor: function (hash_) {
+            if (!hash_) { return window.dash_clientside.no_update; }
+            var id = hash_.replace(/^#/, "");
+            var stopAt = Date.now() + 6000;
+            var armed = false;
+            var timer = setInterval(function () {
+                var el = document.getElementById(id);
+                if (el) {
+                    el.scrollIntoView({ block: "center", behavior: "instant" });
+                    if (!armed) {
+                        armed = true;
+                        var cancel = function () { clearInterval(timer); };
+                        window.addEventListener("wheel", cancel, { passive: true, once: true });
+                        window.addEventListener("touchmove", cancel, { passive: true, once: true });
+                    }
+                }
+                if (Date.now() > stopAt) { clearInterval(timer); }
+            }, 200);
+            return window.dash_clientside.no_update;
+        },
+    },
+});

--- a/8Knot/pages/codebase/codebase.py
+++ b/8Knot/pages/codebase/codebase.py
@@ -14,20 +14,20 @@ dash.register_page(__name__, path="/codebase")
 
 layout = dbc.Container(
     [
+        # Anchor ids now live on the heatmap cards themselves (VisualizationAIO
+        # id=...), consistent with every other graph — so they are not repeated
+        # here (duplicate ids would be invalid).
         dbc.Row(
             dbc.Col(gc_contribution_file_heatmap, xl=10),
             className="visualization-row",
-            id="contribution-file-heatmap",
         ),
         dbc.Row(
             dbc.Col(gc_cntrb_file_heatmap, xl=10),
             className="visualization-row",
-            id="cntrb-file-heatmap",
         ),
         dbc.Row(
             dbc.Col(gc_reviewer_file_heatmap, xl=10),
             className="visualization-row",
-            id="reviewer-file-heatmap",
         ),
     ],
     fluid=True,

--- a/8Knot/pages/codebase/codebase.py
+++ b/8Knot/pages/codebase/codebase.py
@@ -14,9 +14,6 @@ dash.register_page(__name__, path="/codebase")
 
 layout = dbc.Container(
     [
-        # Anchor ids now live on the heatmap cards themselves (VisualizationAIO
-        # id=...), consistent with every other graph — so they are not repeated
-        # here (duplicate ids would be invalid).
         dbc.Row(
             dbc.Col(gc_contribution_file_heatmap, xl=10),
             className="visualization-row",

--- a/8Knot/pages/codebase/visualizations/cntrb_file_heatmap.py
+++ b/8Knot/pages/codebase/visualizations/cntrb_file_heatmap.py
@@ -75,6 +75,7 @@ gc_cntrb_file_heatmap = VisualizationAIO(
         ),
     ],
     class_name="dark-card",
+    id="cntrb-file-heatmap",
 )
 
 

--- a/8Knot/pages/codebase/visualizations/contribution_file_heatmap.py
+++ b/8Knot/pages/codebase/visualizations/contribution_file_heatmap.py
@@ -90,6 +90,7 @@ gc_contribution_file_heatmap = VisualizationAIO(
         ),
     ],
     class_name="dark-card",
+    id="contribution-file-heatmap",
 )
 
 

--- a/8Knot/pages/codebase/visualizations/reviewer_file_heatmap.py
+++ b/8Knot/pages/codebase/visualizations/reviewer_file_heatmap.py
@@ -75,6 +75,7 @@ gc_reviewer_file_heatmap = VisualizationAIO(
         ),
     ],
     class_name="dark-card",
+    id="reviewer-file-heatmap",
 )
 
 

--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -7,7 +7,7 @@ import json
 from celery.result import AsyncResult
 import dash_bootstrap_components as dbc
 import dash
-from dash import callback, html
+from dash import callback, html, clientside_callback, ClientsideFunction
 from dash.dependencies import Input, Output, State, MATCH
 from app import augur
 from flask_login import current_user
@@ -897,3 +897,13 @@ def update_pill_color_on_search(search_button_clicks, selected_repos_orgs):
         return "searchbar-dropdown"
 
     return dash.no_update
+
+
+# Scroll the URL's #fragment graph card into view on every hash change.
+# Implementation (and the reasoning for it) lives in assets/scroll_to_anchor.js.
+clientside_callback(
+    ClientsideFunction(namespace="eightknot", function_name="scroll_to_anchor"),
+    Output("anchor-scroll-dummy", "data"),
+    Input("url", "hash"),
+    prevent_initial_call=False,
+)

--- a/8Knot/pages/index/index_components.py
+++ b/8Knot/pages/index/index_components.py
@@ -271,6 +271,8 @@ def create_app_stores():
         dcc.Store(id="repo-choices", storage_type="session", data=[]),
         dcc.Store(id="job-ids", storage_type="session", data=[]),
         dcc.Store(id="user-group-loading-signal", data="", storage_type="memory"),
+        # no-op output sink for the clientside scroll-to-anchor callback
+        dcc.Store(id="anchor-scroll-dummy", data=None),
         dcc.Location(id="url"),
     ]
 


### PR DESCRIPTION
This PR implements the anchor fix and url handler to correctly center the page on the graph being shared.

Two fixes make URLs land centered on the target graph:

1. Sidebar anchors now use each card's real DOM id, f"{PAGE}-{VIZ_ID}" — the old fragments matched no element, and PAGE is not derivable from the pathname (e.g. /repo_overview cards are repo_info-*). Clicking a sidebar graph now also puts a copyable, shareable anchor URL in the address bar.

2. A clientside handler scrolls to the fragment. The browser's native hash scroll fires before Dash client-side-renders the page (why a correct anchor still does nothing in prod), so the handler polls for the card, centers it, re-scrolls through the async graph-load reflow, and cancels if the user scrolls.

### Pull Request Change Description
<!-- Please give a thorough descriptions of the intended changes made by this PR -->

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc --> Claude Fable
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc --> Draft and review.
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... --> Yes, reviewed and tested.
