### PR TITLE
Add EIGHTKNOT_CONTRIBUTOR_LABEL to optionally show GitHub usernames

### DIFF
--- a/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
+++ b/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
@@ -7,7 +7,7 @@ import pandas as pd
 import logging
 from dateutil.relativedelta import *  # type: ignore
 import plotly.express as px
-from pages.utils.graph_utils import get_graph_time_values, baby_blue
+from pages.utils.graph_utils import get_graph_time_values, baby_blue, contributor_label
 from queries.contributors_query import contributors_query as ctq
 from pages.utils.job_utils import nodata_graph
 import time
@@ -203,7 +203,13 @@ def process_data(df: pd.DataFrame, action_type, top_k, start_date, end_date):
     t_sum = df.shape[0]
 
     # count the number of contributions for each contributor
-    df = (df.groupby("cntrb_id")["Action"].count()).to_frame()
+    label_col, _ = contributor_label()
+
+    # not every contributor has a GitHub account, so keep the id where login is null
+    if label_col != "cntrb_id":
+        df[label_col] = df[label_col].fillna(df["cntrb_id"])
+
+    df = (df.groupby(label_col)["Action"].count()).to_frame()
 
     # sort rows according to amount of contributions from greatest to least
     df.sort_values(by="Action", ascending=False, inplace=True)
@@ -222,30 +228,32 @@ def process_data(df: pd.DataFrame, action_type, top_k, start_date, end_date):
     # calculate the remaining contributions by taking the the difference of t_sum and df_sum
     # dataframes no longer implement above 'append' interface as of Pandas 1.4.4
     # create a single-entry dataframe that we can concatenate onto existing df
-    df_concat = pd.DataFrame(data={"cntrb_id": ["Other"], action_type: [t_sum - df_sum]})
+    df_concat = pd.DataFrame(data={label_col: ["Other"], action_type: [t_sum - df_sum]})
     df = pd.concat([df, df_concat], ignore_index=True)
 
     return df
 
 
 def create_figure(df: pd.DataFrame, action_type):
+    label_col, label_name = contributor_label()
+
     # create plotly express pie chart
     fig = px.pie(
         df,
-        names="cntrb_id",  # can be replaced with login to unanonymize
+        names=label_col,
         values=action_type,
         color_discrete_sequence=baby_blue,
     )
 
-    # display percent contributions and cntrb_id in each wedge
-    # format hover template to display cntrb_id and the number of their contributions according to the action_type
+    # display percent contributions and the contributor label in each wedge
+    # format hover template to display the contributor label and their contribution count for the action_type
     fig.update_traces(
         textinfo="percent+label",
         textposition="inside",
-        hovertemplate="Contributor ID: %{label} <br>Contributions: %{value}<br><extra></extra>",
+        hovertemplate=f"{label_name}: %{{label}} <br>Contributions: %{{value}}<br><extra></extra>",
     )
 
     # add legend title
-    fig.update_layout(legend_title_text="Contributor ID")
+    fig.update_layout(legend_title_text=label_name)
 
     return fig

--- a/8Knot/pages/contributors/visualizations/contrib_importance_pie.py
+++ b/8Knot/pages/contributors/visualizations/contrib_importance_pie.py
@@ -7,7 +7,7 @@ import pandas as pd
 import logging
 from dateutil.relativedelta import *  # type: ignore
 import plotly.express as px
-from pages.utils.graph_utils import baby_blue
+from pages.utils.graph_utils import baby_blue, contributor_label
 from queries.contributors_query import contributors_query as ctq
 from pages.utils.job_utils import nodata_graph
 import time
@@ -217,7 +217,13 @@ def process_data(df: pd.DataFrame, action_type, top_k, start_date, end_date):
     t_sum = df.shape[0]
 
     # count the number of contributions for each contributor
-    df = (df.groupby("cntrb_id")["Action"].count()).to_frame()
+    label_col, _ = contributor_label()
+
+    # not every contributor has a GitHub account, so keep the id where login is null
+    if label_col != "cntrb_id":
+        df[label_col] = df[label_col].fillna(df["cntrb_id"])
+
+    df = (df.groupby(label_col)["Action"].count()).to_frame()
 
     # sort rows according to amount of contributions from greatest to least
     df.sort_values(by="Action", ascending=False, inplace=True)
@@ -239,27 +245,29 @@ def process_data(df: pd.DataFrame, action_type, top_k, start_date, end_date):
     # calculate the remaining contributions by taking the the difference of t_sum and df_sum
     # dataframes no longer implement above 'append' interface as of Pandas 1.4.4
     # create a single-entry dataframe that we can concatenate onto existing df
-    df_concat = pd.DataFrame(data={"cntrb_id": ["Other"], action_type: [t_sum - df_sum]})
+    df_concat = pd.DataFrame(data={label_col: ["Other"], action_type: [t_sum - df_sum]})
     df = pd.concat([df, df_concat], ignore_index=True)
 
     return df
 
 
 def create_figure(df: pd.DataFrame, action_type):
+    label_col, label_name = contributor_label()
+
     # create plotly express pie chart
     fig = px.pie(
         df,
-        names="cntrb_id",  # can be replaced with login to unanonymize
+        names=label_col,
         values=action_type,
         color_discrete_sequence=baby_blue,
     )
 
-    # display percent contributions and cntrb_id in each wedge
-    # format hover template to display cntrb_id and the number of their contributions according to the action_type
+    # display percent contributions and the contributor label in each wedge
+    # format hover template to display the contributor label and their contribution count for the action_type
     fig.update_traces(
         textinfo="percent+label",
         textposition="inside",
-        hovertemplate="Contributor ID: %{label} <br>Contributions: %{value}<br><extra></extra>",
+        hovertemplate=f"{label_name}: %{{label}} <br>Contributions: %{{value}}<br><extra></extra>",
     )
 
     return fig

--- a/8Knot/pages/utils/graph_utils.py
+++ b/8Knot/pages/utils/graph_utils.py
@@ -1,3 +1,4 @@
+import os
 import datetime as dt
 
 import pandas as pd
@@ -123,3 +124,23 @@ def get_graph_time_values(interval):
         period = "M12"
 
     return x_r, x_name, hover, period
+
+
+def contributor_label():
+    """Column and display name to use when labelling contributors in a graph.
+
+    8Knot anonymizes contributors by default, labelling them with a truncated
+    contributor UUID. That is the right default for a public deployment, but a
+    deployment tracking only public repositories often wants the GitHub
+    username, which is already public information and much easier to read.
+
+    Set EIGHTKNOT_CONTRIBUTOR_LABEL=login to opt in. Anything else, including
+    unset, keeps the existing anonymized behavior. The graphs that call this are
+    background callbacks, so the variable has to reach worker-callback -- setting
+    it only on app-server does nothing.
+
+    Returns a (column, display name) pair.
+    """
+    if os.getenv("EIGHTKNOT_CONTRIBUTOR_LABEL", "id").lower() == "login":
+        return "login", "Contributor"
+    return "cntrb_id", "Contributor ID"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,10 @@ services:
       - postgres-cache
     env_file:
       - .env
+    environment:
+      # The graphs are background callbacks, so they are built here rather than
+      # in app-server. Setting this on app-server has no effect.
+      - EIGHTKNOT_CONTRIBUTOR_LABEL=id  # id (default, anonymized) or login (GitHub username)
     restart: always
 
   worker-query:


### PR DESCRIPTION
## Pull Request Change Description

When I'm viewing the two "contributor importance" pies, the wedges are labeled with a truncated contributor UUID. This anonymization is a good default, but it makes it harder to show off the graphs with the same meaning as having usernames. The 8Knot code already hints at wanting a choice here:

```python
names="cntrb_id",  # can be replaced with login to unanonymize
```

This PR makes that change a setting rather than requiring a source edit. `EIGHTKNOT_CONTRIBUTOR_LABEL=login` labels with the GitHub username instead. Default is `id`, so nothing changes unless you opt in. I could not find anything written down about why the default is anonymized, so I left it alone rather than guess — if there is a reason it should stay that way even as an option, I would rather hear it than work around it.

It is not quite a one-liner fix, which is probably why the comment is still a comment. `groupby("cntrb_id")`
drops the `login` column before `create_figure` ever sees it, so the grouping key, the synthetic
"Other" row, and the legend and hover strings all have to move together. `contributor_label()` in
`graph_utils` returns the column and its display name so both pies stay in step.

Contributors with no GitHub account fall back to their ID rather than collapsing into one blank wedge.

One thing worth flagging: the setting goes on `worker-callback`, not `app-server`. I had it on
`app-server` at first, which does nothing — both pies are `background=True`, so they are built in the
callback worker. Running it both ways against a real database:

```
label var on app-server only  ->  0105ec0b-8800-0, 01061cd8-3000-0, ...   legend: Contributor ID
label var on worker-callback  ->  nickleodoen, sammshen, ApostaC, ...     legend: Contributor
```

Verified end to end against ~31k contributor-action rows: identical wedge values in both modes
(305, 301, 201, 141, 123, 111, 1924), so switching the grouping key regroups nobody, and the
null-login rows survive as their own wedge instead of being absorbed into "Other". I checked the
touched Python stays within the repo's 120-column black setting, but I did not have black itself
available to run, so please let pre-commit be the judge.

Where this came from: I am running 8Knot against an Aveloxis backend. Everything we track is public,
so the UUIDs were pure friction for us. Happy to be told this belongs somewhere else in the config, or
to extend it to the assignment charts — those hardcode "Contributor ID" as a legend title and would
need `login` plumbed through their queries first, so I left them out to keep this small.

Pull Request Change Description
This updates the landing page language from Augur to CollectOSS. It is one part of many other things that need renaming per https://github.com/oss-aspen/8Knot/issues/1136, this PR just addresses the most public-facing instance of it (the first thing people see when they load 8Knot).

## Generative AI disclosure
Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.

If AI tools were used, please provide details below:
- What tools were used?
  - Claude Code and Opus 4.8
- How were these tools used?
  - I practice AI-pair programming, meaning I use XP processes when I develop using genAI coding tools, such as creating user stories of 3 points or fewer to keep the coding model on track (and using a PRD for full projects).
- Did you review these outputs before submitting this PR?
  - Very carefully, for both my personal education and to check the work to the best of my abilities as a technical expert non-coder. To make sure the concepts and architecture of the solution were sound, I used a different model to analyze the approach and the PR, and do a gap analysis with the fresh context. Ironically, I didn't manage to extend that to cover PR guidelines for this project and that's why I am adding this section on genAI disclosure after the fact.
  - I'm not tied to the code or technical implementation of the idea, if it's a better approach for the project to reimplement this idea from scratch by a maintainer, I'm perfectly fine with that. I'm also open for discussing different approaches that better preserve the 8Knot intentions and goals. Thanks! 🙏