### PR TITLE
fix: start db-init in podman e2e by gating on service_started

### DIFF
--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -66,6 +66,9 @@ jobs:
 
           yq eval -i '.services.mock-db.image = "ghcr.io/chaoss/augur_empty_database:latest"' docker-compose.yml
 
+          # gate db-init on service_started (podman compose skips healthchecks)
+          yq eval -i '.services.db-init.depends_on.postgres-cache.condition = "service_started"' docker-compose.yml
+
       - name: Setup Podman Compose
         uses: webgtx/setup-podman-compose@v1
 


### PR DESCRIPTION
### Pull Request Change Description
<!-- Please give a thorough descriptions of the intended changes made by this PR -->

The **Podman** end-to-end job has been failing, while the **Docker** job passes. It is **not** related to the augur→collectoss rename — all `AUGUR:` log strings still match (the Docker job matches all 9 patterns and goes green).

It seems that newer podman compose on the ubuntu-latest runner does not run compose-defined healthchecks, so postgres-cache never reports healthy. db-init is the only service that depends on it via condition: service_healthy, so db-init never starts — and app-server → reverse-proxy cascade off it. With db-init never running, augur_cache is never created and the awaited log lines (Database connection established successfully!, ALL TABLES COMMITTED SUCCESSFULLY, POSTGRES CACHE SUCCESSFULLY INITIALIZED) never appear. Services using short-form depends_on (service_started) all start fine, which is why the workers run.

## Fix

CI-only: We just change the dependency on postgres-cache from service-healthy to service-started via `yq`. `db_init.py` already retries the connection itself (`_connect_with_retry`, 5×3s), and postgres-cache accepts connections within ~2s, so the readiness gap is covered.

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc --> Claude
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc --> Draft/Analysis.
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... --> Yes.